### PR TITLE
Will you change EventInterface to public?

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -1,7 +1,7 @@
 //! Contract event.
 
 use std::collections::HashMap;
-use spec::{Event as EventInterface, ParamType};
+use spec::{Event as EventInterface, ParamType, EventParam};
 use decoder::Decoder;
 use token::Token;
 use error::Error;
@@ -100,9 +100,9 @@ impl Event {
 		&self.interface.name
 	}
 
-	/// EventInterface getter
-	pub fn interface(&self) -> &EventInterface {
-		&self.interface
+	/// Return the inputs of the event.
+	pub fn inputs(&self) -> &Vec<EventParam> {
+		&self.interface.inputs
 	}
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -17,7 +17,8 @@ pub struct DecodedLog {
 
 /// Contract event.
 pub struct Event {
-	interface: EventInterface,
+	/// spec::Event
+	pub interface: EventInterface,
 }
 
 impl Event {

--- a/src/event.rs
+++ b/src/event.rs
@@ -101,7 +101,7 @@ impl Event {
 	}
 
 	/// Return the inputs of the event.
-	pub fn inputs(&self) -> &Vec<EventParam> {
+	pub fn inputs(&self) -> &[EventParam] {
 		&self.interface.inputs
 	}
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -18,7 +18,7 @@ pub struct DecodedLog {
 /// Contract event.
 pub struct Event {
 	/// spec::Event
-	pub interface: EventInterface,
+	interface: EventInterface,
 }
 
 impl Event {
@@ -98,6 +98,11 @@ impl Event {
 	/// Return the name of the event.
 	pub fn name(&self) -> &str {
 		&self.interface.name
+	}
+
+	/// EventInterface getter
+	pub fn interface(&self) -> &EventInterface {
+		&self.interface
 	}
 }
 


### PR DESCRIPTION
I want to execute this code.

    let abi = ethabi::Contract::new(ethabi::Interface::load(json.as_slice()).unwrap());
    let events = abi.events().map(|event| {
        let params = event.interface.inputs.iter().map(|event_param| {
            event_param.kind.clone()
        } ).collect::<Vec<_>>();
        (H256::from(event_signature(&event.interface.name, params.as_slice()).as_ref()), event)
    });

Thank you.