### PR TITLE
Index contract operations

### DIFF
--- a/src/constructor.rs
+++ b/src/constructor.rs
@@ -6,6 +6,7 @@ use error::Error;
 use encoder::Encoder;
 
 /// Contract constructor call builder.
+#[derive(Clone, Debug)]
 pub struct Constructor {
 	_interface: ConstructorInterface,
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -16,6 +16,7 @@ pub struct DecodedLog {
 }
 
 /// Contract event.
+#[derive(Clone, Debug)]
 pub struct Event {
 	interface: EventInterface,
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -8,6 +8,7 @@ use signature::signature;
 use error::Error;
 
 /// Contract function call builder.
+#[derive(Clone, Debug)]
 pub struct Function {
 	interface: FunctionInterface,
 }

--- a/src/spec/interface.rs
+++ b/src/spec/interface.rs
@@ -14,6 +14,9 @@ impl Interface {
 	}
 
 	/// Returns contract constructor specification.
+	// TODO: these methods can be removed in a future major version as they are
+	//       currently unused and the same functionality can be achieved with
+	//       Contract
 	pub fn constructor(&self) -> Option<Constructor> {
 		self.0.iter()
 			.filter_map(Operation::constructor)


### PR DESCRIPTION
Index the contract operations by name (and the constructor separately) to avoid performing linear search on each lookup. Fixes #20.