### PR TITLE
Ignore signature when parsing function names

### DIFF
--- a/src/spec/operation.rs
+++ b/src/spec/operation.rs
@@ -133,4 +133,31 @@ mod tests {
 		test_sanitize_function_name("()", "");
 		test_sanitize_function_name("", "");
 	}
+
+	#[test]
+	fn deserialize_sanitize_event_name() {
+		fn test_sanitize_event_name(name: &str, expected: &str) {
+			let s = format!(r#"{{
+				"type":"event",
+					"inputs": [{{
+						"name":"a",
+						"type":"address",
+						"indexed":true
+					}}],
+					"name":"{}",
+					"outputs": [],
+					"anonymous": false
+			}}"#, name);
+
+			let deserialized: Operation = serde_json::from_str(&s).unwrap();
+			let event = deserialized.event().unwrap();
+
+			assert_eq!(event.name, expected);
+		}
+
+		test_sanitize_event_name("foo", "foo");
+		test_sanitize_event_name("foo()", "foo");
+		test_sanitize_event_name("()", "");
+		test_sanitize_event_name("", "");
+	}
 }

--- a/src/spec/operation.rs
+++ b/src/spec/operation.rs
@@ -100,4 +100,29 @@ mod tests {
 			outputs: vec![]
 		}));
 	}
+
+	#[test]
+	fn deserialize_sanitize_function_name() {
+		fn test_sanitize_function_name(name: &str, expected: &str) {
+			let s = format!(r#"{{
+				"type":"function",
+				"inputs": [{{
+					"name":"a",
+					"type":"address"
+				}}],
+				"name":"{}",
+				"outputs": []
+			}}"#, name);
+
+			let deserialized: Operation = serde_json::from_str(&s).unwrap();
+			let function = deserialized.function().unwrap();
+
+			assert_eq!(function.name, expected);
+		}
+
+		test_sanitize_function_name("foo", "foo");
+		test_sanitize_function_name("foo()", "foo");
+		test_sanitize_function_name("()", "");
+		test_sanitize_function_name("", "");
+	}
 }


### PR DESCRIPTION
Fixes #10.