### PR TITLE
Add the packaging metadata to build the ethabi snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: ethabi
+version: master
+summary: encodes smart contracts function calls and decodes their output
+description: |
+  An Ethereum smart contract is bytecode, EVM, on the Ethereum blockchain.
+  Among the EVM, there could be several functions in a contract. An ABI is
+  necessary so that you can specify which function in the contract to invoke,
+  as well as get a guarantee that the function will return data in the format
+  you are expecting.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  ethabi:
+    command: ethabi
+    plugs: [home]
+
+parts:
+  ethabi:
+    source: .
+    source-subdir: cli
+    plugin: rust


### PR DESCRIPTION
This package will let you publish the latest parity in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress.