### PR TITLE
Relax required types where possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "ethabi-cli"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 2.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "ethabi-cli"
 version = "2.0.1"
 dependencies = [
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethabi 2.0.0",
+ "ethabi 3.0.0",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -36,7 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ethabi"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethabi"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 homepage = "https://github.com/paritytech/ethabi"
 license = "MIT"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,7 @@ rustc-hex = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
 docopt = "0.8.1"
-ethabi = { version = "2.0", path = ".." }
+ethabi = { version = "3.0", path = ".." }
 
 [[bin]]
 name = "ethabi"

--- a/src/constructor.rs
+++ b/src/constructor.rs
@@ -21,7 +21,7 @@ impl Constructor {
 	}
 
 	/// Prepares ABI constructor call with given input params.
-	pub fn encode_call(&self, tokens: Vec<Token>) -> Result<Vec<u8>, Error> {
+	pub fn encode_call(&self, tokens: &[Token]) -> Result<Vec<u8>, Error> {
 		let params = self._interface.param_types();
 
 		if type_check(&tokens, &params) {

--- a/src/constructor.rs
+++ b/src/constructor.rs
@@ -4,7 +4,7 @@ use spec::Constructor as ConstructorInterface;
 use function::type_check;
 use token::Token;
 use error::Error;
-use encoder::Encoder;
+use encoder::encode;
 
 /// Contract constructor call builder.
 #[derive(Clone, Debug)]
@@ -25,7 +25,7 @@ impl Constructor {
 		let params = self._interface.param_types();
 
 		if type_check(&tokens, &params) {
-			Ok(Encoder::encode(tokens))
+			Ok(encode(tokens))
 		} else {
 			Err(Error::InvalidData)
 		}

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -5,9 +5,6 @@ use error::Error;
 use token::Token;
 use util::slice_data;
 
-/// ABI decoder.
-pub struct Decoder;
-
 struct DecodeResult {
 	token: Token,
 	new_offset: usize,
@@ -39,173 +36,171 @@ fn as_bool(slice: &[u8; 32]) -> Result<bool, Error> {
 	Ok(slice[31] == 1)
 }
 
-impl Decoder {
-	/// Decodes ABI compliant vector of bytes into vector of tokens described by types param.
-	pub fn decode(types: &[ParamType], data: &[u8]) -> Result<Vec<Token>, Error> {
-		let slices = try!(slice_data(data));
-		let mut tokens = vec![];
-		let mut offset = 0;
-		for param in types {
-			let res = try!(Self::decode_param(param, &slices, offset));
-			offset = res.new_offset;
-			tokens.push(res.token);
-		}
-		Ok(tokens)
+/// Decodes ABI compliant vector of bytes into vector of tokens described by types param.
+pub fn decode(types: &[ParamType], data: &[u8]) -> Result<Vec<Token>, Error> {
+	let slices = try!(slice_data(data));
+	let mut tokens = vec![];
+	let mut offset = 0;
+	for param in types {
+		let res = try!(decode_param(param, &slices, offset));
+		offset = res.new_offset;
+		tokens.push(res.token);
+	}
+	Ok(tokens)
+}
+
+fn peek(slices: &Vec<[u8; 32]>, position: usize) -> Result<&[u8; 32], Error> {
+	slices.get(position).ok_or(Error::InvalidData)
+}
+
+fn take_bytes(slices: &Vec<[u8; 32]>, position: usize, len: usize) -> Result<BytesTaken, Error> {
+	let slices_len = (len + 31) / 32;
+
+	let mut bytes_slices = vec![];
+	for i in 0..slices_len {
+		let slice = try!(peek(slices, position + i)).clone();
+		bytes_slices.push(slice);
 	}
 
-	fn peek(slices: &Vec<[u8; 32]>, position: usize) -> Result<&[u8; 32], Error> {
-		slices.get(position).ok_or(Error::InvalidData)
-	}
+	let bytes = bytes_slices.into_iter()
+		.flat_map(|slice| slice.to_vec())
+		.take(len)
+		.collect();
 
-	fn take_bytes(slices: &Vec<[u8; 32]>, position: usize, len: usize) -> Result<BytesTaken, Error> {
-		let slices_len = (len + 31) / 32;
+	let taken = BytesTaken {
+		bytes: bytes,
+		new_offset: position + slices_len,
+	};
 
-		let mut bytes_slices = vec![];
-		for i in 0..slices_len {
-			let slice = try!(Self::peek(slices, position + i)).clone();
-			bytes_slices.push(slice);
-		}
+	Ok(taken)
+}
 
-		let bytes = bytes_slices.into_iter()
-			.flat_map(|slice| slice.to_vec())
-			.take(len)
-			.collect();
+fn decode_param(param: &ParamType, slices: &Vec<[u8; 32]>, offset: usize) -> Result<DecodeResult, Error> {
+	match *param {
+		ParamType::Address => {
+			let slice = try!(peek(slices, offset));
+			let mut address = [0u8; 20];
+			address.copy_from_slice(&slice[12..]);
 
-		let taken = BytesTaken {
-			bytes: bytes,
-			new_offset: position + slices_len,
-		};
+			let result = DecodeResult {
+				token: Token::Address(address),
+				new_offset: offset + 1,
+			};
 
-		Ok(taken)
-	}
+			Ok(result)
+		},
+		ParamType::Int(_) => {
+			let slice = try!(peek(slices, offset));
 
-	fn decode_param(param: &ParamType, slices: &Vec<[u8; 32]>, offset: usize) -> Result<DecodeResult, Error> {
-		match *param {
-			ParamType::Address => {
-				let slice = try!(Self::peek(slices, offset));
-				let mut address = [0u8; 20];
-				address.copy_from_slice(&slice[12..]);
+			let result = DecodeResult {
+				token: Token::Int(slice.clone()),
+				new_offset: offset + 1,
+			};
 
-				let result = DecodeResult {
-					token: Token::Address(address),
-					new_offset: offset + 1,
-				};
+			Ok(result)
+		},
+		ParamType::Uint(_) => {
+			let slice = try!(peek(slices, offset));
 
-				Ok(result)
-			},
-			ParamType::Int(_) => {
-				let slice = try!(Self::peek(slices, offset));
+			let result = DecodeResult {
+				token: Token::Uint(slice.clone()),
+				new_offset: offset + 1,
+			};
 
-				let result = DecodeResult {
-					token: Token::Int(slice.clone()),
-					new_offset: offset + 1,
-				};
+			Ok(result)
+		},
+		ParamType::Bool => {
+			let slice = try!(peek(slices, offset));
 
-				Ok(result)
-			},
-			ParamType::Uint(_) => {
-				let slice = try!(Self::peek(slices, offset));
+			let b = try!(as_bool(slice));
 
-				let result = DecodeResult {
-					token: Token::Uint(slice.clone()),
-					new_offset: offset + 1,
-				};
+			let result = DecodeResult {
+				token: Token::Bool(b),
+				new_offset: offset + 1,
+			};
 
-				Ok(result)
-			},
-			ParamType::Bool => {
-				let slice = try!(Self::peek(slices, offset));
+			Ok(result)
+		},
+		ParamType::FixedBytes(len) => {
+			let taken = try!(take_bytes(slices, offset, len));
 
-				let b = try!(as_bool(slice));
+			let result = DecodeResult {
+				token: Token::FixedBytes(taken.bytes),
+				new_offset: taken.new_offset,
+			};
 
-				let result = DecodeResult {
-					token: Token::Bool(b),
-					new_offset: offset + 1,
-				};
+			Ok(result)
+		},
+		ParamType::Bytes => {
+			let offset_slice = try!(peek(slices, offset));
+			let len_offset = (try!(as_u32(offset_slice)) / 32) as usize;
 
-				Ok(result)
-			},
-			ParamType::FixedBytes(len) => {
-				let taken = try!(Self::take_bytes(slices, offset, len));
+			let len_slice = try!(peek(slices, len_offset));
+			let len = try!(as_u32(len_slice)) as usize;
 
-				let result = DecodeResult {
-					token: Token::FixedBytes(taken.bytes),
-					new_offset: taken.new_offset,
-				};
+			let taken = try!(take_bytes(slices, len_offset + 1, len));
 
-				Ok(result)
-			},
-			ParamType::Bytes => {
-				let offset_slice = try!(Self::peek(slices, offset));
-				let len_offset = (try!(as_u32(offset_slice)) / 32) as usize;
+			let result = DecodeResult {
+				token: Token::Bytes(taken.bytes),
+				new_offset: offset + 1,
+			};
 
-				let len_slice = try!(Self::peek(slices, len_offset));
-				let len = try!(as_u32(len_slice)) as usize;
+			Ok(result)
+		},
+		ParamType::String => {
+			let offset_slice = try!(peek(slices, offset));
+			let len_offset = (try!(as_u32(offset_slice)) / 32) as usize;
 
-				let taken = try!(Self::take_bytes(slices, len_offset + 1, len));
+			let len_slice = try!(peek(slices, len_offset));
+			let len = try!(as_u32(len_slice)) as usize;
 
-				let result = DecodeResult {
-					token: Token::Bytes(taken.bytes),
-					new_offset: offset + 1,
-				};
+			let taken = try!(take_bytes(slices, len_offset + 1, len));
 
-				Ok(result)
-			},
-			ParamType::String => {
-				let offset_slice = try!(Self::peek(slices, offset));
-				let len_offset = (try!(as_u32(offset_slice)) / 32) as usize;
+			let result = DecodeResult {
+				token: Token::String(try!(String::from_utf8(taken.bytes))),
+				new_offset: offset + 1,
+			};
 
-				let len_slice = try!(Self::peek(slices, len_offset));
-				let len = try!(as_u32(len_slice)) as usize;
+			Ok(result)
+		},
+		ParamType::Array(ref t) => {
+			let offset_slice = try!(peek(slices, offset));
+			let len_offset = (try!(as_u32(offset_slice)) / 32) as usize;
 
-				let taken = try!(Self::take_bytes(slices, len_offset + 1, len));
+			let len_slice = try!(peek(slices, len_offset));
+			let len = try!(as_u32(len_slice)) as usize;
 
-				let result = DecodeResult {
-					token: Token::String(try!(String::from_utf8(taken.bytes))),
-					new_offset: offset + 1,
-				};
+			let mut tokens = vec![];
+			let mut new_offset = len_offset + 1;
 
-				Ok(result)
-			},
-			ParamType::Array(ref t) => {
-				let offset_slice = try!(Self::peek(slices, offset));
-				let len_offset = (try!(as_u32(offset_slice)) / 32) as usize;
-
-				let len_slice = try!(Self::peek(slices, len_offset));
-				let len = try!(as_u32(len_slice)) as usize;
-
-				let mut tokens = vec![];
-				let mut new_offset = len_offset + 1;
-
-				for _ in 0..len {
-					let res = try!(Self::decode_param(t, &slices, new_offset));
-					new_offset = res.new_offset;
-					tokens.push(res.token);
-				}
-
-				let result = DecodeResult {
-					token: Token::Array(tokens),
-					new_offset: offset + 1,
-				};
-
-				Ok(result)
-			},
-			ParamType::FixedArray(ref t, len) => {
-				let mut tokens = vec![];
-				let mut new_offset = offset;
-				for _ in 0..len {
-					let res = try!(Self::decode_param(t, &slices, new_offset));
-					new_offset = res.new_offset;
-					tokens.push(res.token);
-				}
-
-				let result = DecodeResult {
-					token: Token::FixedArray(tokens),
-					new_offset: new_offset,
-				};
-
-				Ok(result)
+			for _ in 0..len {
+				let res = try!(decode_param(t, &slices, new_offset));
+				new_offset = res.new_offset;
+				tokens.push(res.token);
 			}
+
+			let result = DecodeResult {
+				token: Token::Array(tokens),
+				new_offset: offset + 1,
+			};
+
+			Ok(result)
+		},
+		ParamType::FixedArray(ref t, len) => {
+			let mut tokens = vec![];
+			let mut new_offset = offset;
+			for _ in 0..len {
+				let res = try!(decode_param(t, &slices, new_offset));
+				new_offset = res.new_offset;
+				tokens.push(res.token);
+			}
+
+			let result = DecodeResult {
+				token: Token::FixedArray(tokens),
+				new_offset: new_offset,
+			};
+
+			Ok(result)
 		}
 	}
 }
@@ -215,14 +210,14 @@ mod tests {
 	use hex::FromHex;
 	use token::Token;
 	use spec::ParamType;
-	use super::{Decoder};
+	use super::decode;
 
 	#[test]
 	fn decode_address() {
 		let encoded = "0000000000000000000000001111111111111111111111111111111111111111".from_hex().unwrap();
 		let address = Token::Address([0x11u8; 20]);
 		let expected = vec![address];
-		let decoded = Decoder::decode(&[ParamType::Address], encoded).unwrap();
+		let decoded = decode(&[ParamType::Address], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
 
@@ -234,7 +229,7 @@ mod tests {
 		let address1 = Token::Address([0x11u8; 20]);
 		let address2 = Token::Address([0x22u8; 20]);
 		let expected = vec![address1, address2];
-		let decoded = Decoder::decode(&[ParamType::Address, ParamType::Address], encoded).unwrap();
+		let decoded = decode(&[ParamType::Address, ParamType::Address], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
 
@@ -246,7 +241,7 @@ mod tests {
 		let address1 = Token::Address([0x11u8; 20]);
 		let address2 = Token::Address([0x22u8; 20]);
 		let expected = vec![Token::FixedArray(vec![address1, address2])];
-		let decoded = Decoder::decode(&[ParamType::FixedArray(Box::new(ParamType::Address), 2)], encoded).unwrap();
+		let decoded = decode(&[ParamType::FixedArray(Box::new(ParamType::Address), 2)], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
 
@@ -255,7 +250,7 @@ mod tests {
 		let encoded = "1111111111111111111111111111111111111111111111111111111111111111".from_hex().unwrap();
 		let uint = Token::Uint([0x11u8; 32]);
 		let expected = vec![uint];
-		let decoded = Decoder::decode(&[ParamType::Uint(32)], encoded).unwrap();
+		let decoded = decode(&[ParamType::Uint(32)], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
 
@@ -264,7 +259,7 @@ mod tests {
 		let encoded = "1111111111111111111111111111111111111111111111111111111111111111".from_hex().unwrap();
 		let int = Token::Int([0x11u8; 32]);
 		let expected = vec![int];
-		let decoded = Decoder::decode(&[ParamType::Int(32)], encoded).unwrap();
+		let decoded = decode(&[ParamType::Int(32)], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
 
@@ -279,7 +274,7 @@ mod tests {
 		let address2 = Token::Address([0x22u8; 20]);
 		let addresses = Token::Array(vec![address1, address2]);
 		let expected = vec![addresses];
-		let decoded = Decoder::decode(&[ParamType::Array(Box::new(ParamType::Address))], encoded).unwrap();
+		let decoded = decode(&[ParamType::Array(Box::new(ParamType::Address))], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
 
@@ -300,11 +295,11 @@ mod tests {
 		let array1 = Token::FixedArray(vec![address3, address4]);
 		let dynamic = Token::Array(vec![array0, array1]);
 		let expected = vec![dynamic];
-		let decoded = Decoder::decode(&[
+		let decoded = decode(&[
 			ParamType::Array(Box::new(
 				ParamType::FixedArray(Box::new(ParamType::Address), 2)
 			))
-		], encoded).unwrap();
+		], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
 
@@ -326,11 +321,11 @@ mod tests {
 		let array1 = Token::Array(vec![address2]);
 		let dynamic = Token::Array(vec![array0, array1]);
 		let expected = vec![dynamic];
-		let decoded = Decoder::decode(&[
+		let decoded = decode(&[
 			ParamType::Array(Box::new(
 				ParamType::Array(Box::new(ParamType::Address))
 			))
-		], encoded).unwrap();
+		], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
 
@@ -356,11 +351,11 @@ mod tests {
 		let array1 = Token::Array(vec![address3, address4]);
 		let dynamic = Token::Array(vec![array0, array1]);
 		let expected = vec![dynamic];
-		let decoded = Decoder::decode(&[
+		let decoded = decode(&[
 			ParamType::Array(Box::new(
 				ParamType::Array(Box::new(ParamType::Address))
 			))
-		], encoded).unwrap();
+		], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
 
@@ -380,12 +375,12 @@ mod tests {
 		let fixed = Token::FixedArray(vec![array0, array1]);
 		let expected = vec![fixed];
 
-		let decoded = Decoder::decode(&[
+		let decoded = decode(&[
 			ParamType::FixedArray(
 				Box::new(ParamType::FixedArray(Box::new(ParamType::Address), 2)),
 				2
 			)
-		], encoded).unwrap();
+		], &encoded).unwrap();
 
 		assert_eq!(decoded, expected);
 	}
@@ -410,12 +405,12 @@ mod tests {
 		let fixed = Token::FixedArray(vec![array0, array1]);
 		let expected = vec![fixed];
 
-		let decoded = Decoder::decode(&[
+		let decoded = decode(&[
 			ParamType::FixedArray(
 				Box::new(ParamType::Array(Box::new(ParamType::Address))),
 				2
 			)
-		], encoded).unwrap();
+		], &encoded).unwrap();
 
 		assert_eq!(decoded, expected);
 	}
@@ -426,7 +421,7 @@ mod tests {
 			"1234000000000000000000000000000000000000000000000000000000000000").from_hex().unwrap();
 		let bytes = Token::FixedBytes(vec![0x12, 0x34]);
 		let expected = vec![bytes];
-		let decoded = Decoder::decode(&[ParamType::FixedBytes(2)], encoded).unwrap();
+		let decoded = decode(&[ParamType::FixedBytes(2)], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
 
@@ -438,7 +433,7 @@ mod tests {
 			"1234000000000000000000000000000000000000000000000000000000000000").from_hex().unwrap();
 		let bytes = Token::Bytes(vec![0x12, 0x34]);
 		let expected = vec![bytes];
-		let decoded = Decoder::decode(&[ParamType::Bytes], encoded).unwrap();
+		let decoded = decode(&[ParamType::Bytes], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
 
@@ -453,7 +448,7 @@ mod tests {
 			"1000000000000000000000000000000000000000000000000000000000000000" +
 			"1000000000000000000000000000000000000000000000000000000000000000").from_hex().unwrap());
 		let expected = vec![bytes];
-		let decoded = Decoder::decode(&[ParamType::Bytes], encoded).unwrap();
+		let decoded = decode(&[ParamType::Bytes], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
 
@@ -469,7 +464,7 @@ mod tests {
 		let bytes1 = Token::Bytes("10000000000000000000000000000000000000000000000000000000000002".from_hex().unwrap());
 		let bytes2 = Token::Bytes("0010000000000000000000000000000000000000000000000000000000000002".from_hex().unwrap());
 		let expected = vec![bytes1, bytes2];
-		let decoded = Decoder::decode(&[ParamType::Bytes, ParamType::Bytes], encoded).unwrap();
+		let decoded = decode(&[ParamType::Bytes, ParamType::Bytes], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
 
@@ -481,7 +476,7 @@ mod tests {
 			"6761766f66796f726b0000000000000000000000000000000000000000000000").from_hex().unwrap();
 		let s = Token::String("gavofyork".to_owned());
 		let expected = vec![s];
-		let decoded = Decoder::decode(&[ParamType::String], encoded).unwrap();
+		let decoded = decode(&[ParamType::String], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -41,7 +41,7 @@ fn as_bool(slice: &[u8; 32]) -> Result<bool, Error> {
 
 impl Decoder {
 	/// Decodes ABI compliant vector of bytes into vector of tokens described by types param.
-	pub fn decode(types: &[ParamType], data: Vec<u8>) -> Result<Vec<Token>, Error> {
+	pub fn decode(types: &[ParamType], data: &[u8]) -> Result<Vec<Token>, Error> {
 		let slices = try!(slice_data(data));
 		let mut tokens = vec![];
 		let mut offset = 0;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -173,7 +173,7 @@ mod tests {
 	#[test]
 	fn encode_address() {
 		let address = Token::Address([0x11u8; 20]);
-		let encoded: Vec<_> = encode(vec![address]);
+		let encoded: Vec<_> = encode(&[address]);
 		let expected = "0000000000000000000000001111111111111111111111111111111111111111".from_hex().unwrap();
 		assert_eq!(encoded, expected);
 	}
@@ -183,7 +183,7 @@ mod tests {
 		let address1 = Token::Address([0x11u8; 20]);
 		let address2 = Token::Address([0x22u8; 20]);
 		let addresses = Token::Array(vec![address1, address2]);
-		let encoded: Vec<_> = encode(vec![addresses]);
+		let encoded: Vec<_> = encode(&[addresses]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000000000000000000000000000000000000000000020" +
 			"0000000000000000000000000000000000000000000000000000000000000002" +
@@ -197,7 +197,7 @@ mod tests {
 		let address1 = Token::Address([0x11u8; 20]);
 		let address2 = Token::Address([0x22u8; 20]);
 		let addresses = Token::FixedArray(vec![address1, address2]);
-		let encoded: Vec<_> = encode(vec![addresses]);
+		let encoded: Vec<_> = encode(&[addresses]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000001111111111111111111111111111111111111111" +
 			"0000000000000000000000002222222222222222222222222222222222222222").from_hex().unwrap();
@@ -208,7 +208,7 @@ mod tests {
 	fn encode_two_addresses() {
 		let address1 = Token::Address([0x11u8; 20]);
 		let address2 = Token::Address([0x22u8; 20]);
-		let encoded: Vec<_> = encode(vec![address1, address2]);
+		let encoded: Vec<_> = encode(&[address1, address2]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000001111111111111111111111111111111111111111" +
 			"0000000000000000000000002222222222222222222222222222222222222222").from_hex().unwrap();
@@ -224,7 +224,7 @@ mod tests {
 		let array0 = Token::Array(vec![address1, address2]);
 		let array1 = Token::Array(vec![address3, address4]);
 		let fixed = Token::FixedArray(vec![array0, array1]);
-		let encoded: Vec<_> = encode(vec![fixed]);
+		let encoded: Vec<_> = encode(&[fixed]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000000000000000000000000000000000000000000040" +
 			"00000000000000000000000000000000000000000000000000000000000000a0" +
@@ -246,7 +246,7 @@ mod tests {
 		let array0 = Token::FixedArray(vec![address1, address2]);
 		let array1 = Token::FixedArray(vec![address3, address4]);
 		let dynamic = Token::Array(vec![array0, array1]);
-		let encoded: Vec<_> = encode(vec![dynamic]);
+		let encoded: Vec<_> = encode(&[dynamic]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000000000000000000000000000000000000000000020" +
 			"0000000000000000000000000000000000000000000000000000000000000002" +
@@ -264,7 +264,7 @@ mod tests {
 		let array0 = Token::Array(vec![address1]);
 		let array1 = Token::Array(vec![address2]);
 		let dynamic = Token::Array(vec![array0, array1]);
-		let encoded: Vec<_> = encode(vec![dynamic]);
+		let encoded: Vec<_> = encode(&[dynamic]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000000000000000000000000000000000000000000020" +
 			"0000000000000000000000000000000000000000000000000000000000000002" +
@@ -286,7 +286,7 @@ mod tests {
 		let array0 = Token::Array(vec![address1, address2]);
 		let array1 = Token::Array(vec![address3, address4]);
 		let dynamic = Token::Array(vec![array0, array1]);
-		let encoded: Vec<_> = encode(vec![dynamic]);
+		let encoded: Vec<_> = encode(&[dynamic]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000000000000000000000000000000000000000000020" +
 			"0000000000000000000000000000000000000000000000000000000000000002" +
@@ -310,7 +310,7 @@ mod tests {
 		let array0 = Token::FixedArray(vec![address1, address2]);
 		let array1 = Token::FixedArray(vec![address3, address4]);
 		let fixed = Token::FixedArray(vec![array0, array1]);
-		let encoded: Vec<_> = encode(vec![fixed]);
+		let encoded: Vec<_> = encode(&[fixed]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000001111111111111111111111111111111111111111" +
 			"0000000000000000000000002222222222222222222222222222222222222222" +
@@ -322,7 +322,7 @@ mod tests {
 	#[test]
 	fn encode_bytes() {
 		let bytes = Token::Bytes(vec![0x12, 0x34]);
-		let encoded: Vec<_> = encode(vec![bytes]);
+		let encoded: Vec<_> = encode(&[bytes]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000000000000000000000000000000000000000000020" +
 			"0000000000000000000000000000000000000000000000000000000000000002" +
@@ -333,7 +333,7 @@ mod tests {
 	#[test]
 	fn encode_fixed_bytes() {
 		let bytes = Token::FixedBytes(vec![0x12, 0x34]);
-		let encoded: Vec<_> = encode(vec![bytes]);
+		let encoded: Vec<_> = encode(&[bytes]);
 		let expected = ("".to_owned() +
 			"1234000000000000000000000000000000000000000000000000000000000000").from_hex().unwrap();
 		assert_eq!(encoded, expected);
@@ -342,7 +342,7 @@ mod tests {
 	#[test]
 	fn encode_string() {
 		let s = Token::String("gavofyork".to_owned());
-		let encoded: Vec<_> = encode(vec![s]);
+		let encoded: Vec<_> = encode(&[s]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000000000000000000000000000000000000000000020" +
 			"0000000000000000000000000000000000000000000000000000000000000009" +
@@ -353,7 +353,7 @@ mod tests {
 	#[test]
 	fn encode_bytes2() {
 		let bytes = Token::Bytes("10000000000000000000000000000000000000000000000000000000000002".from_hex().unwrap());
-		let encoded: Vec<_> = encode(vec![bytes]);
+		let encoded: Vec<_> = encode(&[bytes]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000000000000000000000000000000000000000000020" +
 			"000000000000000000000000000000000000000000000000000000000000001f" +
@@ -366,7 +366,7 @@ mod tests {
 		let bytes = Token::Bytes(("".to_owned() +
 			"1000000000000000000000000000000000000000000000000000000000000000" +
 			"1000000000000000000000000000000000000000000000000000000000000000").from_hex().unwrap());
-		let encoded: Vec<_> = encode(vec![bytes]);
+		let encoded: Vec<_> = encode(&[bytes]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000000000000000000000000000000000000000000020" +
 			"0000000000000000000000000000000000000000000000000000000000000040" +
@@ -379,7 +379,7 @@ mod tests {
 	fn encode_two_bytes() {
 		let bytes1 = Token::Bytes("10000000000000000000000000000000000000000000000000000000000002".from_hex().unwrap());
 		let bytes2 = Token::Bytes("0010000000000000000000000000000000000000000000000000000000000002".from_hex().unwrap());
-		let encoded: Vec<_> = encode(vec![bytes1, bytes2]);
+		let encoded: Vec<_> = encode(&[bytes1, bytes2]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000000000000000000000000000000000000000000040" +
 			"0000000000000000000000000000000000000000000000000000000000000080" +
@@ -394,7 +394,7 @@ mod tests {
 	fn encode_uint() {
 		let mut uint = [0u8; 32];
 		uint[31] = 4;
-		let encoded: Vec<_> = encode(vec![Token::Uint(uint)]);
+		let encoded: Vec<_> = encode(&[Token::Uint(uint)]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000000000000000000000000000000000000000000004").from_hex().unwrap();
 		assert_eq!(encoded, expected);
@@ -404,7 +404,7 @@ mod tests {
 	fn encode_int() {
 		let mut int = [0u8; 32];
 		int[31] = 4;
-		let encoded: Vec<_> = encode(vec![Token::Int(int)]);
+		let encoded: Vec<_> = encode(&[Token::Int(int)]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000000000000000000000000000000000000000000004").from_hex().unwrap();
 		assert_eq!(encoded, expected);
@@ -412,7 +412,7 @@ mod tests {
 
 	#[test]
 	fn encode_bool() {
-		let encoded: Vec<_> = encode(vec![Token::Bool(true)]);
+		let encoded: Vec<_> = encode(&[Token::Bool(true)]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000000000000000000000000000000000000000000001").from_hex().unwrap();
 		assert_eq!(encoded, expected);
@@ -420,7 +420,7 @@ mod tests {
 
 	#[test]
 	fn encode_bool2() {
-		let encoded: Vec<_> = encode(vec![Token::Bool(false)]);
+		let encoded: Vec<_> = encode(&[Token::Bool(false)]);
 		let expected = ("".to_owned() +
 			"0000000000000000000000000000000000000000000000000000000000000000").from_hex().unwrap();
 		assert_eq!(encoded, expected);
@@ -431,7 +431,7 @@ mod tests {
 		let bytes = ("".to_owned() +
 			"131a3afc00d1b1e3461b955e53fc866dcf303b3eb9f4c16f89e388930f48134b" +
 			"131a3afc00d1b1e3461b955e53fc866dcf303b3eb9f4c16f89e388930f48134b").from_hex().unwrap();
-		let encoded: Vec<_> = encode(vec![
+		let encoded: Vec<_> = encode(&[
 			Token::Int(pad_u32(5)),
 			Token::Bytes(bytes.clone()),
 			Token::Int(pad_u32(3)),
@@ -461,7 +461,7 @@ mod tests {
 
 	#[test]
 	fn comprehensive_test2() {
-		let encoded: Vec<_> = encode(vec![
+		let encoded: Vec<_> = encode(&[
 			Token::Int(pad_u32(1)),
 			Token::String("gavofyork".to_owned()),
 			Token::Int(pad_u32(2)),

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2,6 +2,7 @@
 
 use token::Token;
 use util::pad_u32;
+use std::iter::FromIterator;
 
 fn pad_bytes(bytes: Vec<u8>) -> Vec<[u8; 32]> {
 	let mut result = vec![pad_u32(bytes.len() as u32)];
@@ -115,7 +116,7 @@ pub struct Encoder;
 
 impl Encoder {
 	/// Encodes vector of tokens into ABI compliant vector of bytes.
-	pub fn encode(tokens: Vec<Token>) -> Vec<u8> {
+	pub fn encode<T: FromIterator<u8>>(tokens: Vec<Token>) -> T {
 		let mediates: Vec<Mediate> = tokens.into_iter()
 			.map(Self::encode_token)
 			.collect();

--- a/src/event.rs
+++ b/src/event.rs
@@ -49,7 +49,7 @@ impl Event {
 
 		let mut result = topics.into_iter()
 			.map(|topic| {
-				let encoded = Encoder::encode(vec![topic]);
+				let encoded: Vec<_> = Encoder::encode(vec![topic]);
 				if encoded.len() == 32 {
 					let mut data = [0u8; 32];
 					data.copy_from_slice(&encoded);
@@ -68,7 +68,7 @@ impl Event {
 	}
 
 	/// Decodes event indexed params and data.
-	pub fn decode_log(&self, topics: Vec<[u8; 32]>, data: Vec<u8>) -> Result<Vec<LogParam>, Error> {
+	pub fn decode_log(&self, topics: Vec<[u8; 32]>, data: &[u8]) -> Result<Vec<LogParam>, Error> {
 		let topics_len = topics.len();
 		// obtains all params info
 		let topic_params = self.interface.indexed_params(true);
@@ -94,7 +94,7 @@ impl Event {
 			.flat_map(|t| t.to_vec())
 			.collect::<Vec<u8>>();
 
-		let topic_tokens = try!(Decoder::decode(&topic_types, flat_topics));
+		let topic_tokens = try!(Decoder::decode(&topic_types, &flat_topics));
 
 		// topic may be only a 32 bytes encoded token
 		if topic_tokens.len() != topics_len - to_skip {

--- a/src/event.rs
+++ b/src/event.rs
@@ -3,11 +3,11 @@
 use std::collections::HashMap;
 use tiny_keccak::keccak256;
 use spec::{Event as EventInterface, ParamType, EventParam};
-use decoder::Decoder;
+use decoder::decode;
+use encoder::encode;
 use token::Token;
 use error::Error;
 use signature::long_signature;
-use Encoder;
 
 /// Decoded log param.
 #[derive(Debug, PartialEq)]
@@ -49,7 +49,7 @@ impl Event {
 
 		let mut result = topics.into_iter()
 			.map(|topic| {
-				let encoded: Vec<_> = Encoder::encode(vec![topic]);
+				let encoded: Vec<_> = encode(vec![topic]);
 				if encoded.len() == 32 {
 					let mut data = [0u8; 32];
 					data.copy_from_slice(&encoded);
@@ -94,7 +94,7 @@ impl Event {
 			.flat_map(|t| t.to_vec())
 			.collect::<Vec<u8>>();
 
-		let topic_tokens = try!(Decoder::decode(&topic_types, &flat_topics));
+		let topic_tokens = try!(decode(&topic_types, &flat_topics));
 
 		// topic may be only a 32 bytes encoded token
 		if topic_tokens.len() != topics_len - to_skip {
@@ -109,7 +109,7 @@ impl Event {
 			.map(|p| p.kind.clone())
 			.collect::<Vec<ParamType>>();
 
-		let data_tokens = try!(Decoder::decode(&data_types, data));
+		let data_tokens = try!(decode(&data_types, data));
 
 		let data_named_tokens = data_params.into_iter()
 			.map(|p| p.name)
@@ -181,7 +181,7 @@ mod tests {
 				"0000000000000000000000000000000000000000000000000000000000000002".token_from_hex().unwrap(),
 				"0000000000000000000000001111111111111111111111111111111111111111".token_from_hex().unwrap(),
 			],
-			("".to_owned() +
+			&("".to_owned() +
 				"0000000000000000000000000000000000000000000000000000000000000003" +
 				"0000000000000000000000002222222222222222222222222222222222222222").from_hex().unwrap()
 		).unwrap();

--- a/src/event.rs
+++ b/src/event.rs
@@ -49,7 +49,7 @@ impl Event {
 
 		let mut result = topics.into_iter()
 			.map(|topic| {
-				let encoded: Vec<_> = encode(vec![topic]);
+				let encoded: Vec<_> = encode(&[topic]);
 				if encoded.len() == 32 {
 					let mut data = [0u8; 32];
 					data.copy_from_slice(&encoded);

--- a/src/function.rs
+++ b/src/function.rs
@@ -91,7 +91,7 @@ mod tests {
 		let func = Function::new(interface);
 		let mut uint = [0u8; 32];
 		uint[31] = 69;
-		let encoded: Vec<_> = func.encode_call(vec![Token::Uint(uint), Token::Bool(true)]).unwrap();
+		let encoded: Vec<_> = func.encode_call(&[Token::Uint(uint), Token::Bool(true)]).unwrap();
 		let expected = "cdcd77c000000000000000000000000000000000000000000000000000000000000000450000000000000000000000000000000000000000000000000000000000000001".from_hex().unwrap();
 		assert_eq!(encoded, expected);
 	}

--- a/src/function.rs
+++ b/src/function.rs
@@ -2,8 +2,8 @@
 
 use spec::{Function as FunctionInterface, ParamType};
 use token::Token;
-use encoder::Encoder;
-use decoder::Decoder;
+use encoder::encode;
+use decoder::decode;
 use signature::short_signature;
 use error::Error;
 use std::iter::FromIterator;
@@ -41,13 +41,13 @@ impl Function {
 		}
 
 		let signed = short_signature(&self.interface.name, &params).to_vec();
-		let encoded: Vec<_> = Encoder::encode(tokens);
+		let encoded: Vec<_> = encode(tokens);
 		Ok(signed.into_iter().chain(encoded.into_iter()).collect())
 	}
 
 	/// Parses the ABI function output to list of tokens.
 	pub fn decode_output(&self, data: &[u8]) -> Result<Vec<Token>, Error> {
-		Decoder::decode(&self.interface.output_param_types(), data)
+		decode(&self.interface.output_param_types(), data)
 	}
 
 	/// Get the name of the function.
@@ -91,7 +91,7 @@ mod tests {
 		let func = Function::new(interface);
 		let mut uint = [0u8; 32];
 		uint[31] = 69;
-		let encoded = func.encode_call(vec![Token::Uint(uint), Token::Bool(true)]).unwrap();
+		let encoded: Vec<_> = func.encode_call(vec![Token::Uint(uint), Token::Bool(true)]).unwrap();
 		let expected = "cdcd77c000000000000000000000000000000000000000000000000000000000000000450000000000000000000000000000000000000000000000000000000000000001".from_hex().unwrap();
 		assert_eq!(encoded, expected);
 	}

--- a/src/function.rs
+++ b/src/function.rs
@@ -6,6 +6,7 @@ use encoder::Encoder;
 use decoder::Decoder;
 use signature::short_signature;
 use error::Error;
+use std::iter::FromIterator;
 
 /// Contract function call builder.
 #[derive(Clone, Debug)]
@@ -32,7 +33,7 @@ impl Function {
 	}
 
 	/// Prepares ABI function call with given input params.
-	pub fn encode_call(&self, tokens: Vec<Token>) -> Result<Vec<u8>, Error> {
+	pub fn encode_call<T: FromIterator<u8>>(&self, tokens: Vec<Token>) -> Result<T, Error> {
 		let params = self.interface.input_param_types();
 
 		if !type_check(&tokens, &params) {
@@ -40,12 +41,12 @@ impl Function {
 		}
 
 		let signed = short_signature(&self.interface.name, &params).to_vec();
-		let encoded = Encoder::encode(tokens);
+		let encoded: Vec<_> = Encoder::encode(tokens);
 		Ok(signed.into_iter().chain(encoded.into_iter()).collect())
 	}
 
 	/// Parses the ABI function output to list of tokens.
-	pub fn decode_output(&self, data: Vec<u8>) -> Result<Vec<Token>, Error> {
+	pub fn decode_output(&self, data: &[u8]) -> Result<Vec<Token>, Error> {
 		Decoder::decode(&self.interface.output_param_types(), data)
 	}
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -33,7 +33,7 @@ impl Function {
 	}
 
 	/// Prepares ABI function call with given input params.
-	pub fn encode_call<T: FromIterator<u8>>(&self, tokens: Vec<Token>) -> Result<T, Error> {
+	pub fn encode_call<T: FromIterator<u8>>(&self, tokens: &[Token]) -> Result<T, Error> {
 		let params = self.interface.input_param_types();
 
 		if !type_check(&tokens, &params) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ pub use self::constructor::Constructor;
 pub use self::contract::Contract;
 pub use self::token::Token;
 pub use self::error::Error;
-pub use self::encoder::Encoder;
-pub use self::decoder::Decoder;
+pub use self::encoder::encode;
+pub use self::decoder::decode;
 pub use self::function::Function;
 pub use self::event::{Event, LogParam};
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@
 use error::Error;
 
 /// Convers vector of bytes with len equal n * 32, to a vector of slices.
-pub fn slice_data(data: Vec<u8>) -> Result<Vec<[u8; 32]>, Error> {
+pub fn slice_data(data: &[u8]) -> Result<Vec<[u8; 32]>, Error> {
 	if data.len() % 32 != 0 {
 		return Err(Error::InvalidData);
 	}


### PR DESCRIPTION
A lot of the functions that return or take a `Vec` could be relaxed to take a `&[u8]` or return a `T: FromIterator<u8>`. This commit does that. This is a breaking change, but a minor one. If we don't want to make breaking changes I can write versions of the functions that have the relaxed signature and have the existing functions call into them.

This is part of converting `Vec<u8>` to `Bytes`, which is a prelude to the future queue overhaul.