### PR TITLE
Implement call_async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,9 @@ dependencies = [
 [[package]]
 name = "ethabi-contract"
 version = "4.2.0"
+dependencies = [
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "ethabi-derive"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,13 +1,3 @@
-[root]
-name = "ethabi-tests"
-version = "0.1.0"
-dependencies = [
- "ethabi 4.1.0",
- "ethabi-contract 4.1.0",
- "ethabi-derive 4.1.0",
- "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "aho-corasick"
 version = "0.6.3"
@@ -120,6 +110,22 @@ dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ethabi-tests"
+version = "0.1.0"
+dependencies = [
+ "ethabi 4.1.0",
+ "ethabi-contract 4.1.0",
+ "ethabi-derive 4.1.0",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "heck"
@@ -318,6 +324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b5b93718f8b3e5544fcc914c43de828ca6c6ace23e0332c6080a2977b49787a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "118b49cac82e04121117cbd3121ede3147e885627d82c4546b87c702debb90c1"
 "checksum heck 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e0db42a2924a5d7d628685e7a8cf9a2edd628650a9d01efc3dde35d3cdd22451"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "aho-corasick"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -15,7 +15,7 @@ dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -25,13 +25,13 @@ name = "backtrace-sys"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -55,8 +55,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -79,9 +79,9 @@ version = "4.1.0"
 dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -93,13 +93,13 @@ dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 4.1.0",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ethabi-contract"
-version = "4.1.0"
+version = "4.2.0"
 
 [[package]]
 name = "ethabi-derive"
@@ -116,7 +116,7 @@ name = "ethabi-tests"
 version = "0.1.0"
 dependencies = [
  "ethabi 4.1.0",
- "ethabi-contract 4.1.0",
+ "ethabi-contract 4.2.0",
  "ethabi-derive 4.1.0",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -156,15 +156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -183,7 +183,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -206,22 +206,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.15"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.15"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -230,13 +230,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -318,7 +318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f2ce94e22b8e664d95c57fff45b98a966c2252b60691d0b7aeeccd88d70983"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
-"checksum cc 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2c674f0870e3dbd4105184ea035acb1c32c8ae69939c9e228d2b11bbfe29efad"
+"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b5b93718f8b3e5544fcc914c43de828ca6c6ace23e0332c6080a2977b49787a"
@@ -329,18 +329,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
-"checksum libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "56cce3130fd040c28df6f495c8492e5ec5808fb4c9093c310df02b0c8f030148"
-"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
+"checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
+"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0ceb8ce7a5e520de349e1fa172baeba4a9e8d5ef06c47471863530bc4972ee1e"
-"checksum serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "6a7046c9d4c6c522d10b2d098f9bebe2bef227e0e74044d8c1bfcf6b476af799"
-"checksum serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1afcaae083fd1c46952a315062326bc9957f182358eb7da03b57ef1c688f7aa9"
-"checksum serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd381f6d01a6616cdba8530492d453b7761b456ba974e98768a18cad2cd76f58"
-"checksum serde_json 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ee28c1d94a7745259b767ca9e5b95d55bafbd3205ca3acb978cad84a6ed6bc62"
+"checksum serde 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "5a2b181dd2b4a6353e828e44807269a761d3ecbc388a1f5ed3998ea69a516d9c"
+"checksum serde_derive 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "31ce3c16ec18abb97d977f75880986549213b0c18f2695eda8b31eadc96eda4a"
+"checksum serde_derive_internals 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32f1926285523b2db55df263d2aa4eb69ddcfa7a7eade6430323637866b513ab"
+"checksum serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e4586746d1974a030c48919731ecffd0ed28d0c40749d0d18d43b3a7d6c9b20e"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethabi-contract"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 homepage = "https://github.com/paritytech/ethabi"
 license = "MIT"

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -6,3 +6,6 @@ homepage = "https://github.com/paritytech/ethabi"
 license = "MIT"
 keywords = ["ethereum", "eth", "abi", "solidity", "derive"]
 description = "Easy to use conversion of ethereum contract calls to bytecode."
+
+[dependencies]
+futures = "0.1"

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -11,12 +11,12 @@ macro_rules! use_contract {
 }
 
 #[macro_export]
-macro_rules! use_contract_futures {
+macro_rules! use_contract_async {
 	($module: ident, $name: expr, $path: expr) => {
 		#[allow(dead_code)]
 		pub mod $module {
 			#[derive(EthabiContract)]
-			#[ethabi_contract_options(name = $name, path = $path, futures)]
+			#[ethabi_contract_options(name = $name, path = $path, async)]
 			struct _Dummy;
 		}
 	}

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,3 +1,5 @@
+pub extern crate futures;
+
 #[macro_export]
 macro_rules! use_contract {
 	($module: ident, $name: expr, $path: expr) => {
@@ -5,18 +7,6 @@ macro_rules! use_contract {
 		pub mod $module {
 			#[derive(EthabiContract)]
 			#[ethabi_contract_options(name = $name, path = $path)]
-			struct _Dummy;
-		}
-	}
-}
-
-#[macro_export]
-macro_rules! use_contract_async {
-	($module: ident, $name: expr, $path: expr) => {
-		#[allow(dead_code)]
-		pub mod $module {
-			#[derive(EthabiContract)]
-			#[ethabi_contract_options(name = $name, path = $path, async)]
 			struct _Dummy;
 		}
 	}

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -9,3 +9,15 @@ macro_rules! use_contract {
 		}
 	}
 }
+
+#[macro_export]
+macro_rules! use_contract_futures {
+	($module: ident, $name: expr, $path: expr) => {
+		#[allow(dead_code)]
+		pub mod $module {
+			#[derive(EthabiContract)]
+			#[ethabi_contract_options(name = $name, path = $path, futures)]
+			struct _Dummy;
+		}
+	}
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -22,12 +22,11 @@ pub fn ethabi_derive(input: TokenStream) -> TokenStream {
 
 	let options = get_options(&ast.attrs, "ethabi_contract_options").expect(ERROR_MSG);
 	let futures = option_exists(&options, "futures");
-	let path = get_option_value(&options, "path").expect(ERROR_MSG);
-	let name = get_option_value(&options, "name").expect(ERROR_MSG);
+	let path = option_value(&options, "path").expect(ERROR_MSG);
+	let name = option_value(&options, "name").expect(ERROR_MSG);
 	let implementer = EthabiDeriveImplementer { futures, path, name };
 
 	let gen = implementer.implement().expect(ERROR_MSG);
-
 	gen.parse().expect(ERROR_MSG)
 }
 
@@ -49,7 +48,7 @@ fn option_exists<'a>(options: &'a [syn::MetaItem], name: &str) -> bool {
 	options.iter().find(|a| a.name() == name).is_some()
 }
 
-fn get_option_value<'a>(options: &'a [syn::MetaItem], name: &str) -> Result<&'a str> {
+fn option_value<'a>(options: &'a [syn::MetaItem], name: &str) -> Result<&'a str> {
 	let item = options.iter().find(|a| a.name() == name).chain_err(|| format!("Expected to find option {}", name))?;
 	value_of_meta_item(item, name)
 }
@@ -494,7 +493,7 @@ impl<'a> EthabiDeriveImplementer<'a> {
 
 			let call_future_quote = if self.futures {
 				quote! {
-					pub fn call_future</*'s,*/#(#template_params),*>(/*'s */self, #(#params ,)* do_call: &Fn(ethabi::Bytes) -> Box<Future<Item=ethabi::Bytes, Error=String>>) -> Box<Future<Item=#output_kinds, Error=ethabi::Error> /*+ 's*/>
+					pub fn call_future<#(#template_params),*>(self, #(#params ,)* do_call: &Fn(ethabi::Bytes) -> Box<Future<Item=ethabi::Bytes, Error=String>>) -> Box<Future<Item=#output_kinds, Error=ethabi::Error>>
 					{
 						let encoded_input = self.input(#(#names),*);
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -67,7 +67,7 @@ struct EthabiDeriveImplementer<'a> {
 }
 
 impl<'a> EthabiDeriveImplementer<'a> {
-	pub fn implement(self: &Self) -> Result<quote::Tokens> {
+	pub fn implement(&self) -> Result<quote::Tokens> {
 		let normalized_path = Self::normalize_path(self.path)?;
 		let source_file = fs::File::open(&normalized_path)
 			.chain_err(|| format!("Cannot load contract abi from `{}`", normalized_path.display()))?;
@@ -183,7 +183,7 @@ impl<'a> EthabiDeriveImplementer<'a> {
 		Ok(result)
 	}
 
-	fn impl_contract_function(self: &Self, function: &Function) -> quote::Tokens {
+	fn impl_contract_function(&self, function: &Function) -> quote::Tokens {
 		let name = syn::Ident::new(function.name.to_snake_case());
 		let function_name = syn::Ident::new(function.name.to_camel_case());
 
@@ -194,7 +194,7 @@ impl<'a> EthabiDeriveImplementer<'a> {
 		}
 	}
 
-	fn impl_contract_event(self: &Self, event: &Event) -> quote::Tokens {
+	fn impl_contract_event(&self, event: &Event) -> quote::Tokens {
 		let name = syn::Ident::new(event.name.to_snake_case());
 		let event_name = syn::Ident::new(event.name.to_camel_case());
 		quote! {
@@ -204,7 +204,7 @@ impl<'a> EthabiDeriveImplementer<'a> {
 		}
 	}
 
-	fn impl_contract_constructor(self: &Self, constructor: &Constructor) -> quote::Tokens {
+	fn impl_contract_constructor(&self, constructor: &Constructor) -> quote::Tokens {
 		// [param0, hello_world, param2]
 		let names: Vec<_> = constructor.inputs
 			.iter()
@@ -261,7 +261,7 @@ impl<'a> EthabiDeriveImplementer<'a> {
 		}
 	}
 
-	fn declare_logs(self: &Self, event: &Event) -> quote::Tokens {
+	fn declare_logs(&self, event: &Event) -> quote::Tokens {
 		let name = syn::Ident::new(event.name.to_camel_case());
 		let names: Vec<_> = event.inputs
 			.iter()
@@ -286,7 +286,7 @@ impl<'a> EthabiDeriveImplementer<'a> {
 		}
 	}
 
-	fn declare_events(self: &Self, event: &Event) -> quote::Tokens {
+	fn declare_events(&self, event: &Event) -> quote::Tokens {
 		let name = syn::Ident::new(event.name.to_camel_case());
 
 		// parse log
@@ -410,7 +410,7 @@ impl<'a> EthabiDeriveImplementer<'a> {
 		}
 	}
 
-	fn declare_functions(self: &Self, function: &Function) -> quote::Tokens {
+	fn declare_functions(&self, function: &Function) -> quote::Tokens {
 		let name = syn::Ident::new(function.name.to_camel_case());
 
 		// [param0, hello_world, param2]

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -19,115 +19,16 @@ const ERROR_MSG: &'static str = "`derive(EthabiContract)` failed";
 pub fn ethabi_derive(input: TokenStream) -> TokenStream {
 	let s = input.to_string();
 	let ast = syn::parse_derive_input(&s).expect(ERROR_MSG);
-	let gen = impl_ethabi_derive(&ast).expect(ERROR_MSG);
+
+	let options = get_options(&ast.attrs, "ethabi_contract_options").expect(ERROR_MSG);
+	let futures = option_exists(&options, "futures");
+	let path = get_option_value(&options, "path").expect(ERROR_MSG);
+	let name = get_option_value(&options, "name").expect(ERROR_MSG);
+	let implementer = EthabiDeriveImplementer { futures, path, name };
+
+	let gen = implementer.implement().expect(ERROR_MSG);
+
 	gen.parse().expect(ERROR_MSG)
-}
-
-fn impl_ethabi_derive(ast: &syn::DeriveInput) -> Result<quote::Tokens> {
-	let options = get_options(&ast.attrs, "ethabi_contract_options")?;
-	let path = get_option(&options, "path")?;
-	let normalized_path = normalize_path(path)?;
-	let source_file = fs::File::open(&normalized_path)
-		.chain_err(|| format!("Cannot load contract abi from `{}`", normalized_path.display()))?;
-	let contract = Contract::load(source_file)?;
-
-	let functions: Vec<_> = contract.functions().map(impl_contract_function).collect();
-	let events_impl: Vec<_> = contract.events().map(impl_contract_event).collect();
-	let constructor_impl = contract.constructor.as_ref().map(impl_contract_constructor);
-	let logs_structs: Vec<_> = contract.events().map(declare_logs).collect();
-	let events_structs: Vec<_> = contract.events().map(declare_events).collect();
-	let func_structs: Vec<_> = contract.functions().map(declare_functions).collect();
-
-	let name = get_option(&options, "name")?;
-	let name = syn::Ident::new(name);
-	let functions_name = syn::Ident::new(format!("{}Functions", name));
-	let events_name = syn::Ident::new(format!("{}Events", name));
-
-	let events_and_logs_quote = if events_structs.is_empty() {
-		quote! {}
-	} else {
-		quote! {
-			pub mod events {
-				use ethabi;
-
-				#(#events_structs)*
-			}
-
-			pub mod logs {
-				use ethabi;
-
-				#(#logs_structs)*
-			}
-
-			pub struct #events_name {
-			}
-
-			impl #events_name {
-				#(#events_impl)*
-			}
-
-			impl #name {
-				pub fn events(&self) -> #events_name {
-					#events_name {
-					}
-				}
-			}
-		}
-	};
-
-	let functions_quote = if func_structs.is_empty() {
-		quote! {}
-	} else {
-		quote! {
-			pub mod functions {
-				use ethabi;
-
-				#(#func_structs)*
-			}
-
-			pub struct #functions_name {
-			}
-			impl #functions_name {
-				#(#functions)*
-			}
-			impl #name {
-				pub fn functions(&self) -> #functions_name {
-					#functions_name {}
-				}
-			}
-
-		}
-	};
-
-	let result = quote! {
-		#[allow(unused_imports)]
-		use ethabi; // Not used if no constructor
-
-		#[allow(dead_code)]
-		// Not used in Constructor contract for example
-		const INTERNAL_ERR: &'static str = "`ethabi_derive` internal error";
-
-		/// Contract
-		pub struct #name {
-		}
-
-		impl Default for #name {
-			fn default() -> Self {
-				#name {
-				}
-			}
-		}
-
-		impl #name {
-			#constructor_impl
-		}
-
-		#events_and_logs_quote
-
-		#functions_quote
-	};
-
-	Ok(result)
 }
 
 fn get_options(attrs: &[syn::Attribute], name: &str) -> Result<Vec<syn::MetaItem>> {
@@ -144,530 +45,675 @@ fn get_options(attrs: &[syn::Attribute], name: &str) -> Result<Vec<syn::MetaItem
 	}
 }
 
-fn get_option<'a>(options: &'a [syn::MetaItem], name: &str) -> Result<&'a str> {
+fn option_exists<'a>(options: &'a [syn::MetaItem], name: &str) -> bool {
+	options.iter().find(|a| a.name() == name).is_some()
+}
+
+fn get_option_value<'a>(options: &'a [syn::MetaItem], name: &str) -> Result<&'a str> {
 	let item = options.iter().find(|a| a.name() == name).chain_err(|| format!("Expected to find option {}", name))?;
-	str_value_of_meta_item(item, name)
+	value_of_meta_item(item, name)
 }
 
-fn str_value_of_meta_item<'a>(item: &'a syn::MetaItem, name: &str) -> Result<&'a str> {
-    match *item {
-        syn::MetaItem::NameValue(_, syn::Lit::Str(ref value, _)) => Ok(&*value),
-        _ => Err(format!(r#"`{}` must be in the form `#[{}="something"]`"#, name, name).into()),
-    }
-}
-
-fn normalize_path(relative_path: &str) -> Result<PathBuf> {
-	// workaround for https://github.com/rust-lang/rust/issues/43860
-	let cargo_toml_directory = env::var("CARGO_MANIFEST_DIR").chain_err(|| "Cannot find manifest file")?;
-	let mut path: PathBuf = cargo_toml_directory.into();
-	path.push(relative_path);
-	Ok(path)
-}
-
-fn impl_contract_function(function: &Function) -> quote::Tokens {
-	let name = syn::Ident::new(function.name.to_snake_case());
-	let function_name = syn::Ident::new(function.name.to_camel_case());
-
-	quote! {
-		pub fn #name(&self) -> functions::#function_name {
-			functions::#function_name::default()
-		}
+fn value_of_meta_item<'a>(item: &'a syn::MetaItem, name: &str) -> Result<&'a str> {
+	match *item {
+		syn::MetaItem::NameValue(_, syn::Lit::Str(ref value, _)) => Ok(&*value),
+		_ => Err(format!(r#"`{}` must be in the form `#[{}="something"]`"#, name, name).into()),
 	}
 }
 
-fn to_syntax_string(param_type : &ethabi::ParamType) -> quote::Tokens {
-	match *param_type {
-		ParamType::Address => quote! { ethabi::ParamType::Address },
-		ParamType::Bytes => quote! { ethabi::ParamType::Address },
-		ParamType::Int(x) => quote! { ethabi::ParamType::Int(#x) },
-		ParamType::Uint(x) => quote! { ethabi::ParamType::Uint(#x) },
-		ParamType::Bool => quote! { ethabi::ParamType::Bool },
-		ParamType::String => quote! { ethabi::ParamType::String },
-		ParamType::Array(ref param_type) => {
-			let param_type_quote = to_syntax_string(param_type);
-			quote! { ethabi::ParamType::Array(Box::new(#param_type_quote)) }
-		},
-		ParamType::FixedBytes(x) => quote! { ethabi::ParamType::FixedBytes(#x) },
-		ParamType::FixedArray(ref param_type, ref x) => {
-			let param_type_quote = to_syntax_string(param_type);
-			quote! { ethabi::ParamType::FixedArray(Box::new(#param_type_quote), #x) }
-		}
-	}
+struct EthabiDeriveImplementer<'a> {
+	futures: bool,
+	path: &'a str,
+	name: &'a str,
 }
 
-fn rust_type(input: &ParamType) -> syn::Ident {
-	match *input {
-		ParamType::Address => "ethabi::Address".into(),
-		ParamType::Bytes => "ethabi::Bytes".into(),
-		ParamType::FixedBytes(32) => "ethabi::Hash".into(),
-		ParamType::FixedBytes(size) => format!("[u8; {}]", size).into(),
-		ParamType::Int(_) => "ethabi::Int".into(),
-		ParamType::Uint(_) => "ethabi::Uint".into(),
-		ParamType::Bool => "bool".into(),
-		ParamType::String => "String".into(),
-		ParamType::Array(ref kind) => format!("Vec<{}>", rust_type(&*kind)).into(),
-		ParamType::FixedArray(ref kind, size) => format!("[{}; {}]", rust_type(&*kind), size).into(),
-	}
-}
+impl<'a> EthabiDeriveImplementer<'a> {
+	pub fn implement(self: &Self) -> Result<quote::Tokens> {
+		let normalized_path = Self::normalize_path(self.path)?;
+		let source_file = fs::File::open(&normalized_path)
+			.chain_err(|| format!("Cannot load contract abi from `{}`", normalized_path.display()))?;
+		let contract = Contract::load(source_file)?;
 
-fn template_param_type(input: &ParamType, index: usize) -> syn::Ident {
-	match *input {
-		ParamType::Address => format!("T{}: Into<ethabi::Address>", index).into(),
-		ParamType::Bytes => format!("T{}: Into<ethabi::Bytes>", index).into(),
-		ParamType::FixedBytes(32) => format!("T{}: Into<ethabi::Hash>", index).into(),
-		ParamType::FixedBytes(size) => format!("T{}: Into<[u8; {}]>", index, size).into(),
-		ParamType::Int(_) => format!("T{}: Into<ethabi::Int>", index).into(),
-		ParamType::Uint(_) => format!("T{}: Into<ethabi::Uint>", index).into(),
-		ParamType::Bool => format!("T{}: Into<bool>", index).into(),
-		ParamType::String => format!("T{}: Into<String>", index).into(),
-		ParamType::Array(ref kind) => format!("T{}: IntoIterator<Item = U{}>, U{}: Into<{}>", index, index, index, rust_type(&*kind)).into(),
-		ParamType::FixedArray(ref kind, size) => format!("T{}: Into<[U{}; {}]>, U{}: Into<{}>", index, index, size, index, rust_type(&*kind)).into(),
-	}
-}
+		let functions: Vec<_> = contract.functions().map(|x| self.impl_contract_function(x)).collect();
+		let events_impl: Vec<_> = contract.events().map(|x| self.impl_contract_event(x)).collect();
+		let constructor_impl = contract.constructor.as_ref().map(|x| self.impl_contract_constructor(x));
+		let logs_structs: Vec<_> = contract.events().map(|x| self.declare_logs(x)).collect();
+		let events_structs: Vec<_> = contract.events().map(|x| self.declare_events(x)).collect();
+		let func_structs: Vec<_> = contract.functions().map(|x| self.declare_functions(x)).collect();
 
-fn from_template_param(input: &ParamType, name: &syn::Ident) -> syn::Ident {
-	match *input {
-		ParamType::Array(_) => format!("{}.into_iter().map(Into::into).collect::<Vec<_>>()", name).into(),
-		ParamType::FixedArray(_, _) => format!("(Box::new({}.into()) as Box<[_]>).into_vec().into_iter().map(Into::into).collect::<Vec<_>>()", name).into(),
-		_ => format!("{}.into()", name).into(),
-	}
-}
+		let name = syn::Ident::new(self.name);
+		let functions_name = syn::Ident::new(format!("{}Functions", name));
+		let events_name = syn::Ident::new(format!("{}Events", name));
 
-fn to_token(name: &syn::Ident, kind: &ParamType) -> quote::Tokens {
-	match *kind {
-		ParamType::Address => quote! { ethabi::Token::Address(#name) },
-		ParamType::Bytes => quote! { ethabi::Token::Bytes(#name) },
-		ParamType::FixedBytes(_) => quote! { ethabi::Token::FixedBytes(#name.to_vec()) },
-		ParamType::Int(_) => quote! { ethabi::Token::Int(#name) },
-		ParamType::Uint(_) => quote! { ethabi::Token::Uint(#name) },
-		ParamType::Bool => quote! { ethabi::Token::Bool(#name) },
-		ParamType::String => quote! { ethabi::Token::String(#name) },
-		ParamType::Array(ref kind) => {
-			let inner_name: syn::Ident = "inner".into();
-			let inner_loop = to_token(&inner_name, kind);
-			quote! {
-				// note the double {{
-				{
-					let v = #name.into_iter().map(|#inner_name| #inner_loop).collect();
-					ethabi::Token::Array(v)
-				}
-			}
-		}
-		ParamType::FixedArray(ref kind, _) => {
-			let inner_name: syn::Ident = "inner".into();
-			let inner_loop = to_token(&inner_name, kind);
-			quote! {
-				// note the double {{
-				{
-					let v = #name.into_iter().map(|#inner_name| #inner_loop).collect();
-					ethabi::Token::FixedArray(v)
-				}
-			}
-		},
-	}
-}
-
-fn from_token(kind: &ParamType, token: &syn::Ident) -> quote::Tokens {
-	match *kind {
-		ParamType::Address => quote! { #token.to_address().expect(super::INTERNAL_ERR) },
-		ParamType::Bytes => quote! { #token.to_bytes().expect(super::INTERNAL_ERR) },
-		ParamType::FixedBytes(size) => {
-			let size: syn::Ident = format!("{}", size).into();
-			quote! {
-				{
-					let mut result = [0u8; #size];
-					let v = #token.to_fixed_bytes().expect(super::INTERNAL_ERR);
-					result.copy_from_slice(&v);
-					result
-				}
-			}
-		},
-		ParamType::Int(_) => quote! { #token.to_int().expect(super::INTERNAL_ERR) },
-		ParamType::Uint(_) => quote! { #token.to_uint().expect(super::INTERNAL_ERR) },
-		ParamType::Bool => quote! { #token.to_bool().expect(super::INTERNAL_ERR) },
-		ParamType::String => quote! { #token.to_string().expect(super::INTERNAL_ERR) },
-		ParamType::Array(ref kind) => {
-			let inner: syn::Ident = "inner".into();
-			let inner_loop = from_token(kind, &inner);
-			quote! {
-				#token.to_array().expect(super::INTERNAL_ERR).into_iter()
-					.map(|#inner| #inner_loop)
-					.collect()
-			}
-		},
-		ParamType::FixedArray(ref kind, size) => {
-			let inner: syn::Ident = "inner".into();
-			let inner_loop = from_token(kind, &inner);
-			let to_array = vec![quote! { iter.next() }; size];
-			quote! {
-				{
-					let iter = #token.to_array().expect(super::INTERNAL_ERR).into_iter()
-						.map(|#inner| #inner_loop);
-					[#(#to_array),*]
-				}
-			}
-		},
-	}
-}
-
-fn impl_contract_event(event: &Event) -> quote::Tokens {
-	let name = syn::Ident::new(event.name.to_snake_case());
-	let event_name = syn::Ident::new(event.name.to_camel_case());
-	quote! {
-		pub fn #name(&self) -> events::#event_name {
-			events::#event_name::default()
-		}
-	}
-}
-
-fn impl_contract_constructor(constructor: &Constructor) -> quote::Tokens {
-	// [param0, hello_world, param2]
-	let names: Vec<_> = constructor.inputs
-		.iter()
-		.enumerate()
-		.map(|(index, param)| if param.name.is_empty() {
-			syn::Ident::new(format!("param{}", index))
+		let events_and_logs_quote = if events_structs.is_empty() {
+			quote! {}
 		} else {
-			param.name.to_snake_case().into()
-		}).collect();
+			quote! {
+				pub mod events {
+					use ethabi;
 
-	// [Uint, Bytes, Vec<Uint>]
-	let kinds: Vec<_> = constructor.inputs
-		.iter()
-		.map(|param| rust_type(&param.kind))
-		.collect();
+					#(#events_structs)*
+				}
 
-	// [T0, T1, T2]
-	let template_names: Vec<_> = kinds.iter().enumerate()
-		.map(|(index, _)| syn::Ident::new(format!("T{}", index)))
-		.collect();
+				pub mod logs {
+					use ethabi;
 
-	// [T0: Into<Uint>, T1: Into<Bytes>, T2: IntoIterator<Item = U2>, U2 = Into<Uint>]
-	let template_params: Vec<_> = constructor.inputs.iter().enumerate()
-		.map(|(index, param)| template_param_type(&param.kind, index))
-		.collect();
+					#(#logs_structs)*
+				}
 
-	// [param0: T0, hello_world: T1, param2: T2]
-	let params: Vec<_> = names.iter().zip(template_names.iter())
-		.map(|(param_name, template_name)| quote! { #param_name: #template_name })
-		.collect();
+				pub struct #events_name {
+				}
 
-	// [Token::Uint(param0.into()), Token::Bytes(hello_world.into()), Token::Array(param2.into())]
-	let usage: Vec<_> = names.iter().zip(constructor.inputs.iter())
-		.map(|(param_name, param)| to_token(&from_template_param(&param.kind, param_name), &param.kind))
-		.collect();
+				impl #events_name {
+					#(#events_impl)*
+				}
 
-	let constructor_inputs = &constructor.inputs.iter().map(|x| {
-		let name = &x.name;
-		let kind = to_syntax_string(&x.kind);
-		format!(r##"ethabi::Param {{ name: "{}".to_owned(), kind: {} }}"##, name, kind).into()
-	}).collect::<Vec<syn::Ident>>();
-	let constructor_inputs = quote! { vec![ #(#constructor_inputs),* ] };
-
-	quote! {
-		pub fn constructor<#(#template_params),*>(&self, code: ethabi::Bytes, #(#params),* ) -> ethabi::Bytes {
-			let v: Vec<ethabi::Token> = vec![#(#usage),*];
-
-			ethabi::Constructor {
-				inputs: #constructor_inputs
-			}
-			.encode_input(code, &v)
-			.expect(INTERNAL_ERR)
-		}
-	}
-}
-
-fn declare_logs(event: &Event) -> quote::Tokens {
-	let name = syn::Ident::new(event.name.to_camel_case());
-	let names: Vec<_> = event.inputs
-		.iter()
-		.enumerate()
-		.map(|(index, param)| if param.name.is_empty() {
-			syn::Ident::new(format!("param{}", index))
-		} else {
-			param.name.to_snake_case().into()
-		}).collect();
-	let kinds: Vec<_> = event.inputs
-		.iter()
-		.map(|param| rust_type(&param.kind))
-		.collect();
-	let params: Vec<_> = names.iter().zip(kinds.iter())
-		.map(|(param_name, kind)| quote! { pub #param_name: #kind, })
-		.collect();
-
-	quote! {
-		pub struct #name {
-			#(#params)*
-		}
-	}
-}
-
-fn declare_events(event: &Event) -> quote::Tokens {
-	let name = syn::Ident::new(event.name.to_camel_case());
-
-	// parse log
-
-	let names: Vec<_> = event.inputs
-		.iter()
-		.enumerate()
-		.map(|(index, param)| if param.name.is_empty() {
-			if param.indexed {
-				syn::Ident::new(format!("topic{}", index))
-			} else {
-				syn::Ident::new(format!("param{}", index))
-			}
-		} else {
-			param.name.to_snake_case().into()
-		}).collect();
-
-	let log_iter = syn::Ident::new("log.next().expect(super::INTERNAL_ERR).value");
-
-	let to_log: Vec<_> = event.inputs
-		.iter()
-		.map(|param| from_token(&param.kind, &log_iter))
-		.collect();
-
-	let log_params: Vec<_> = names.iter().zip(to_log.iter())
-		.map(|(param_name, convert)| quote! { #param_name: #convert })
-		.collect();
-
-	// create filter
-
-	let topic_names: Vec<_> = event.inputs
-		.iter()
-		.enumerate()
-		.filter(|&(_, param)| param.indexed)
-		.map(|(index, param)| if param.name.is_empty() {
-			syn::Ident::new(format!("topic{}", index))
-		} else {
-			param.name.to_snake_case().into()
-		})
-		.collect();
-
-	let topic_kinds: Vec<_> = event.inputs
-		.iter()
-		.filter(|param| param.indexed)
-		.map(|param| rust_type(&param.kind))
-		.collect();
-
-	// [T0, T1, T2]
-	let template_names: Vec<_> = topic_kinds.iter().enumerate()
-		.map(|(index, _)| syn::Ident::new(format!("T{}", index)))
-		.collect();
-
-	let params: Vec<_> = topic_names.iter().zip(template_names.iter())
-		.map(|(param_name, template_name)| quote! { #param_name: #template_name })
-		.collect();
-
-	let template_params: Vec<_> = topic_kinds.iter().zip(template_names.iter())
-		.map(|(kind, template_name)| quote! { #template_name: Into<ethabi::Topic<#kind>> })
-		.collect();
-
-	let to_filter: Vec<_> = topic_names.iter().zip(event.inputs.iter().filter(|p| p.indexed))
-		.enumerate()
-		.take(3)
-		.map(|(index, (param_name, param))| {
-			let topic = syn::Ident::new(format!("topic{}", index));
-			let i = "i".into();
-			let to_token = to_token(&i, &param.kind);
-			quote! { #topic: #param_name.into().map(|#i| #to_token), }
-		})
-		.collect();
-
-	let event_name = &event.name;
-
-	let event_inputs = &event.inputs.iter().map(|x| {
-		let name = &x.name;
-		let kind = to_syntax_string(&x.kind);
-		let indexed = x.indexed;
-		format!(r##"ethabi::EventParam {{ name: "{}".to_owned(), kind: {}, indexed: {} }}"##, name, kind, indexed.to_string()).into()
-	}).collect::<Vec<syn::Ident>>();
-	let event_inputs = quote! { vec![ #(#event_inputs),* ] };
-
-	let event_anonymous = &event.anonymous;
-
-
-	quote! {
-		pub struct #name {
-			event: ethabi::Event,
-		}
-
-		impl Default for #name {
-			fn default() -> Self {
-				#name {
-					event: ethabi::Event {
-						name: #event_name.to_owned(),
-						inputs: #event_inputs,
-						anonymous: #event_anonymous
+				impl #name {
+					pub fn events(&self) -> #events_name {
+						#events_name {
+						}
 					}
 				}
 			}
-		}
+		};
 
-		impl #name {
-			/// Parses log.
-			pub fn parse_log(&self, log: ethabi::RawLog) -> ethabi::Result<super::logs::#name> {
-				let mut log = self.event.parse_log(log)?.params.into_iter();
-				let result = super::logs::#name {
-					#(#log_params),*
-				};
-				Ok(result)
-			}
-
-			/// Creates topic filter.
-			pub fn create_filter<#(#template_params),*>(&self, #(#params),*) -> ethabi::TopicFilter {
-				let raw = ethabi::RawTopicFilter {
-					#(#to_filter)*
-					..Default::default()
-				};
-
-				self.event.create_filter(raw).expect(super::INTERNAL_ERR)
-			}
-		}
-	}
-}
-
-fn declare_functions(function: &Function) -> quote::Tokens {
-	let name = syn::Ident::new(function.name.to_camel_case());
-
-	// [param0, hello_world, param2]
-	let ref names: Vec<_> = function.inputs
-		.iter()
-		.enumerate()
-		.map(|(index, param)| if param.name.is_empty() {
-			syn::Ident::new(format!("param{}", index))
+		let functions_quote = if func_structs.is_empty() {
+			quote! {}
 		} else {
-			param.name.to_snake_case().into()
-		}).collect();
+			quote! {
+				pub mod functions {
+					use ethabi;
 
-	// [Uint, Bytes, Vec<Uint>]
-	let kinds: Vec<_> = function.inputs
-		.iter()
-		.map(|param| rust_type(&param.kind))
-		.collect();
+					#(#func_structs)*
+				}
 
-	// [T0, T1, T2]
-	let template_names: Vec<_> = kinds.iter().enumerate()
-		.map(|(index, _)| syn::Ident::new(format!("T{}", index)))
-		.collect();
+				pub struct #functions_name {
+				}
+				impl #functions_name {
+					#(#functions)*
+				}
+				impl #name {
+					pub fn functions(&self) -> #functions_name {
+						#functions_name {}
+					}
+				}
 
-	// [T0: Into<Uint>, T1: Into<Bytes>, T2: IntoIterator<Item = U2>, U2 = Into<Uint>]
-	let ref template_params: Vec<_> = function.inputs.iter().enumerate()
-		.map(|(index, param)| template_param_type(&param.kind, index))
-		.collect();
-
-	// [param0: T0, hello_world: T1, param2: T2]
-	let ref params: Vec<_> = names.iter().zip(template_names.iter())
-		.map(|(param_name, template_name)| quote! { #param_name: #template_name })
-		.collect();
-
-	// [Token::Uint(param0.into()), Token::Bytes(hello_world.into()), Token::Array(param2.into_iter().map(Into::into).collect())]
-	let usage: Vec<_> = names.iter().zip(function.inputs.iter())
-		.map(|(param_name, param)| to_token(&from_template_param(&param.kind, param_name), &param.kind))
-		.collect();
-
-	let output_call_impl = if !function.constant {
-		quote! {}
-	} else {
-		let output_kinds = match function.outputs.len() {
-			0 => quote! {()},
-			1 => {
-				let t = rust_type(&function.outputs[0].kind);
-				quote! { #t }
-			},
-			_ => {
-				let outs: Vec<_> = function.outputs
-					.iter()
-					.map(|param| rust_type(&param.kind))
-					.collect();
-				quote! { (#(#outs),*) }
 			}
 		};
 
-		let o_impl = match function.outputs.len() {
-			0 => quote! { Ok(()) },
-			1 => {
-				let o = "out".into();
-				let from_first = from_token(&function.outputs[0].kind, &o);
-				quote! {
-					let out = self.function.decode_output(output)?.into_iter().next().expect(super::INTERNAL_ERR);
-					Ok(#from_first)
-				}
-			},
-			_ => {
-				let o = "out.next().expect(super::INTERNAL_ERR)".into();
-				let outs: Vec<_> = function.outputs
-					.iter()
-					.map(|param| from_token(&param.kind, &o))
-					.collect();
-
-				quote! {
-					let mut out = self.function.decode_output(output)?.into_iter();
-					Ok(( #(#outs),* ))
-				}
-			},
+		let futures_import_quote = if self.futures {
+			quote! {
+				extern crate futures;
+				#[allow(unused_imports)]
+				use futures::Future;
+			}
+		} else {
+			quote! {}
 		};
+
+		let result = quote! {
+
+			#futures_import_quote
+
+			#[allow(unused_imports)] // Not used if no constructor
+			use ethabi;
+
+			#[allow(dead_code)] // Not used in Constructor contract for example
+			const INTERNAL_ERR: &'static str = "`ethabi_derive` internal error";
+
+			/// Contract
+			pub struct #name {
+			}
+
+			impl Default for #name {
+				fn default() -> Self {
+					#name {
+					}
+				}
+			}
+
+			impl #name {
+				#constructor_impl
+			}
+
+			#events_and_logs_quote
+
+			#functions_quote
+		};
+
+		Ok(result)
+	}
+
+	fn impl_contract_function(self: &Self, function: &Function) -> quote::Tokens {
+		let name = syn::Ident::new(function.name.to_snake_case());
+		let function_name = syn::Ident::new(function.name.to_camel_case());
 
 		quote! {
-			pub fn output(&self, output: &[u8]) -> ethabi::Result<#output_kinds> {
-				#o_impl
-			}
-
-			pub fn call<#(#template_params),*>(&self, #(#params ,)* do_call: &Fn(ethabi::Bytes) -> Result<ethabi::Bytes, String>) -> ethabi::Result<#output_kinds>
-			{
-				let encoded_input = self.input(#(#names),*);
-
-				do_call(encoded_input)
-					.map_err(|x| ethabi::Error::with_chain(ethabi::Error::from(x), ethabi::ErrorKind::CallError))
-					.and_then(|encoded_output| self.output(&encoded_output))
+			pub fn #name(&self) -> functions::#function_name {
+				functions::#function_name::default()
 			}
 		}
-	};
+	}
 
-	let function_name = &function.name;
-
-	let function_inputs = &function.inputs.iter().map(|x| {
-		let name = &x.name;
-		let kind = to_syntax_string(&x.kind);
-		format!(r##"ethabi::Param {{ name: "{}".to_owned(), kind: {} }}"##, name, kind).into()
-	}).collect::<Vec<syn::Ident>>();
-	let function_inputs = quote! { vec![ #(#function_inputs),* ] };
-
-	let function_outputs = &function.outputs.iter().map(|x| {
-		let name = &x.name;
-		let kind = to_syntax_string(&x.kind);
-		format!(r##"ethabi::Param {{ name: "{}".to_owned(), kind: {} }}"##, name, kind).into()
-	}).collect::<Vec<syn::Ident>>();
-	let function_outputs = quote! { vec![ #(#function_outputs),* ] };
-
-	let function_constant = &function.constant;
-
-	quote! {
-		pub struct #name {
-			function: ethabi::Function,
+	fn impl_contract_event(self: &Self, event: &Event) -> quote::Tokens {
+		let name = syn::Ident::new(event.name.to_snake_case());
+		let event_name = syn::Ident::new(event.name.to_camel_case());
+		quote! {
+			pub fn #name(&self) -> events::#event_name {
+				events::#event_name::default()
+			}
 		}
+	}
 
-		impl Default for #name {
-			fn default() -> Self {
-				#name {
-					function: ethabi::Function {
-						name: #function_name.to_owned(),
-						inputs: #function_inputs,
-						outputs: #function_outputs,
-						constant: #function_constant
+	fn impl_contract_constructor(self: &Self, constructor: &Constructor) -> quote::Tokens {
+		// [param0, hello_world, param2]
+		let names: Vec<_> = constructor.inputs
+			.iter()
+			.enumerate()
+			.map(|(index, param)| if param.name.is_empty() {
+				syn::Ident::new(format!("param{}", index))
+			} else {
+				param.name.to_snake_case().into()
+			}).collect();
+
+		// [Uint, Bytes, Vec<Uint>]
+		let kinds: Vec<_> = constructor.inputs
+			.iter()
+			.map(|param| Self::rust_type(&param.kind))
+			.collect();
+
+		// [T0, T1, T2]
+		let template_names: Vec<_> = kinds.iter().enumerate()
+			.map(|(index, _)| syn::Ident::new(format!("T{}", index)))
+			.collect();
+
+		// [T0: Into<Uint>, T1: Into<Bytes>, T2: IntoIterator<Item = U2>, U2 = Into<Uint>]
+		let template_params: Vec<_> = constructor.inputs.iter().enumerate()
+			.map(|(index, param)| Self::template_param_type(&param.kind, index))
+			.collect();
+
+		// [param0: T0, hello_world: T1, param2: T2]
+		let params: Vec<_> = names.iter().zip(template_names.iter())
+			.map(|(param_name, template_name)| quote! { #param_name: #template_name })
+			.collect();
+
+		// [Token::Uint(param0.into()), Token::Bytes(hello_world.into()), Token::Array(param2.into())]
+		let usage: Vec<_> = names.iter().zip(constructor.inputs.iter())
+			.map(|(param_name, param)| Self::to_token(&Self::from_template_param(&param.kind, param_name), &param.kind))
+			.collect();
+
+		let constructor_inputs = &constructor.inputs.iter().map(|x| {
+			let name = &x.name;
+			let kind = Self::to_syntax_string(&x.kind);
+			format!(r##"ethabi::Param {{ name: "{}".to_owned(), kind: {} }}"##, name, kind).into()
+		}).collect::<Vec<syn::Ident>>();
+		let constructor_inputs = quote! { vec![ #(#constructor_inputs),* ] };
+
+		quote! {
+			pub fn constructor<#(#template_params),*>(&self, code: ethabi::Bytes, #(#params),* ) -> ethabi::Bytes {
+				let v: Vec<ethabi::Token> = vec![#(#usage),*];
+
+				ethabi::Constructor {
+					inputs: #constructor_inputs
+				}
+				.encode_input(code, &v)
+				.expect(INTERNAL_ERR)
+			}
+		}
+	}
+
+	fn declare_logs(self: &Self, event: &Event) -> quote::Tokens {
+		let name = syn::Ident::new(event.name.to_camel_case());
+		let names: Vec<_> = event.inputs
+			.iter()
+			.enumerate()
+			.map(|(index, param)| if param.name.is_empty() {
+				syn::Ident::new(format!("param{}", index))
+			} else {
+				param.name.to_snake_case().into()
+			}).collect();
+		let kinds: Vec<_> = event.inputs
+			.iter()
+			.map(|param| Self::rust_type(&param.kind))
+			.collect();
+		let params: Vec<_> = names.iter().zip(kinds.iter())
+			.map(|(param_name, kind)| quote! { pub #param_name: #kind, })
+			.collect();
+
+		quote! {
+			pub struct #name {
+				#(#params)*
+			}
+		}
+	}
+
+	fn declare_events(self: &Self, event: &Event) -> quote::Tokens {
+		let name = syn::Ident::new(event.name.to_camel_case());
+
+		// parse log
+
+		let names: Vec<_> = event.inputs
+			.iter()
+			.enumerate()
+			.map(|(index, param)| if param.name.is_empty() {
+				if param.indexed {
+					syn::Ident::new(format!("topic{}", index))
+				} else {
+					syn::Ident::new(format!("param{}", index))
+				}
+			} else {
+				param.name.to_snake_case().into()
+			}).collect();
+
+		let log_iter = syn::Ident::new("log.next().expect(super::INTERNAL_ERR).value");
+
+		let to_log: Vec<_> = event.inputs
+			.iter()
+			.map(|param| Self::from_token(&param.kind, &log_iter))
+			.collect();
+
+		let log_params: Vec<_> = names.iter().zip(to_log.iter())
+			.map(|(param_name, convert)| quote! { #param_name: #convert })
+			.collect();
+
+		// create filter
+
+		let topic_names: Vec<_> = event.inputs
+			.iter()
+			.enumerate()
+			.filter(|&(_, param)| param.indexed)
+			.map(|(index, param)| if param.name.is_empty() {
+				syn::Ident::new(format!("topic{}", index))
+			} else {
+				param.name.to_snake_case().into()
+			})
+			.collect();
+
+		let topic_kinds: Vec<_> = event.inputs
+			.iter()
+			.filter(|param| param.indexed)
+			.map(|param| Self::rust_type(&param.kind))
+			.collect();
+
+		// [T0, T1, T2]
+		let template_names: Vec<_> = topic_kinds.iter().enumerate()
+			.map(|(index, _)| syn::Ident::new(format!("T{}", index)))
+			.collect();
+
+		let params: Vec<_> = topic_names.iter().zip(template_names.iter())
+			.map(|(param_name, template_name)| quote! { #param_name: #template_name })
+			.collect();
+
+		let template_params: Vec<_> = topic_kinds.iter().zip(template_names.iter())
+			.map(|(kind, template_name)| quote! { #template_name: Into<ethabi::Topic<#kind>> })
+			.collect();
+
+		let to_filter: Vec<_> = topic_names.iter().zip(event.inputs.iter().filter(|p| p.indexed))
+			.enumerate()
+			.take(3)
+			.map(|(index, (param_name, param))| {
+				let topic = syn::Ident::new(format!("topic{}", index));
+				let i = "i".into();
+				let to_token = Self::to_token(&i, &param.kind);
+				quote! { #topic: #param_name.into().map(|#i| #to_token), }
+			})
+			.collect();
+
+		let event_name = &event.name;
+
+		let event_inputs = &event.inputs.iter().map(|x| {
+			let name = &x.name;
+			let kind = Self::to_syntax_string(&x.kind);
+			let indexed = x.indexed;
+			format!(r##"ethabi::EventParam {{ name: "{}".to_owned(), kind: {}, indexed: {} }}"##, name, kind, indexed.to_string()).into()
+		}).collect::<Vec<syn::Ident>>();
+		let event_inputs = quote! { vec![ #(#event_inputs),* ] };
+
+		let event_anonymous = &event.anonymous;
+
+		quote! {
+			pub struct #name {
+				event: ethabi::Event,
+			}
+
+			impl Default for #name {
+				fn default() -> Self {
+					#name {
+						event: ethabi::Event {
+							name: #event_name.to_owned(),
+							inputs: #event_inputs,
+							anonymous: #event_anonymous
+						}
 					}
 				}
 			}
+
+			impl #name {
+				/// Parses log.
+				pub fn parse_log(&self, log: ethabi::RawLog) -> ethabi::Result<super::logs::#name> {
+					let mut log = self.event.parse_log(log)?.params.into_iter();
+					let result = super::logs::#name {
+						#(#log_params),*
+					};
+					Ok(result)
+				}
+
+				/// Creates topic filter.
+				pub fn create_filter<#(#template_params),*>(&self, #(#params),*) -> ethabi::TopicFilter {
+					let raw = ethabi::RawTopicFilter {
+						#(#to_filter)*
+						..Default::default()
+					};
+
+					self.event.create_filter(raw).expect(super::INTERNAL_ERR)
+				}
+			}
 		}
+	}
 
-		impl #name {
+	fn declare_functions(self: &Self, function: &Function) -> quote::Tokens {
+		let name = syn::Ident::new(function.name.to_camel_case());
 
-			pub fn input<#(#template_params),*>(&self, #(#params),*) -> ethabi::Bytes {
-				let v: Vec<ethabi::Token> = vec![#(#usage),*];
-				self.function.encode_input(&v).expect(super::INTERNAL_ERR)
+		// [param0, hello_world, param2]
+		let ref names: Vec<_> = function.inputs
+			.iter()
+			.enumerate()
+			.map(|(index, param)| if param.name.is_empty() {
+				syn::Ident::new(format!("param{}", index))
+			} else {
+				param.name.to_snake_case().into()
+			}).collect();
+
+		// [Uint, Bytes, Vec<Uint>]
+		let kinds: Vec<_> = function.inputs
+			.iter()
+			.map(|param| Self::rust_type(&param.kind))
+			.collect();
+
+		// [T0, T1, T2]
+		let template_names: Vec<_> = kinds.iter().enumerate()
+			.map(|(index, _)| syn::Ident::new(format!("T{}", index)))
+			.collect();
+
+		// [T0: Into<Uint>, T1: Into<Bytes>, T2: IntoIterator<Item = U2>, U2 = Into<Uint>]
+		let ref template_params: Vec<_> = function.inputs.iter().enumerate()
+			.map(|(index, param)| Self::template_param_type(&param.kind, index))
+			.collect();
+
+		// [param0: T0, hello_world: T1, param2: T2]
+		let ref params: Vec<_> = names.iter().zip(template_names.iter())
+			.map(|(param_name, template_name)| quote! { #param_name: #template_name })
+			.collect();
+
+		// [Token::Uint(param0.into()), Token::Bytes(hello_world.into()), Token::Array(param2.into_iter().map(Into::into).collect())]
+		let usage: Vec<_> = names.iter().zip(function.inputs.iter())
+			.map(|(param_name, param)| Self::to_token(&Self::from_template_param(&param.kind, param_name), &param.kind))
+			.collect();
+
+		let output_call_impl = if !function.constant {
+			quote! {}
+		} else {
+			let output_kinds = match function.outputs.len() {
+				0 => quote! {()},
+				1 => {
+					let t = Self::rust_type(&function.outputs[0].kind);
+					quote! { #t }
+				},
+				_ => {
+					let outs: Vec<_> = function.outputs
+						.iter()
+						.map(|param| Self::rust_type(&param.kind))
+						.collect();
+					quote! { (#(#outs),*) }
+				}
+			};
+
+			let o_impl = match function.outputs.len() {
+				0 => quote! { Ok(()) },
+				1 => {
+					let o = "out".into();
+					let from_first = Self::from_token(&function.outputs[0].kind, &o);
+					quote! {
+						let out = self.function.decode_output(output)?.into_iter().next().expect(super::INTERNAL_ERR);
+						Ok(#from_first)
+					}
+				},
+				_ => {
+					let o = "out.next().expect(super::INTERNAL_ERR)".into();
+					let outs: Vec<_> = function.outputs
+						.iter()
+						.map(|param| Self::from_token(&param.kind, &o))
+						.collect();
+
+					quote! {
+						let mut out = self.function.decode_output(output)?.into_iter();
+						Ok(( #(#outs),* ))
+					}
+				},
+			};
+
+			let call_future_quote = if self.futures {
+				quote! {
+					pub fn call_future</*'s,*/#(#template_params),*>(/*'s */self, #(#params ,)* do_call: &Fn(ethabi::Bytes) -> Box<Future<Item=ethabi::Bytes, Error=String>>) -> Box<Future<Item=#output_kinds, Error=ethabi::Error> /*+ 's*/>
+					{
+						let encoded_input = self.input(#(#names),*);
+
+						Box::new(do_call(encoded_input)
+							.map_err(|x| ethabi::Error::with_chain(ethabi::Error::from(x), ethabi::ErrorKind::CallError))
+							.and_then(move |encoded_output| self.output(&encoded_output)))
+					}
+				}
+			} else {
+				quote! {}
+			};
+
+			quote! {
+				pub fn output(&self, output: &[u8]) -> ethabi::Result<#output_kinds> {
+					#o_impl
+				}
+
+				pub fn call<#(#template_params),*>(&self, #(#params ,)* do_call: &Fn(ethabi::Bytes) -> Result<ethabi::Bytes, String>) -> ethabi::Result<#output_kinds>
+				{
+					let encoded_input = self.input(#(#names),*);
+
+					do_call(encoded_input)
+						.map_err(|x| ethabi::Error::with_chain(ethabi::Error::from(x), ethabi::ErrorKind::CallError))
+						.and_then(|encoded_output| self.output(&encoded_output))
+				}
+
+				#call_future_quote
+			}
+		};
+
+		let function_name = &function.name;
+
+		let function_inputs = &function.inputs.iter().map(|x| {
+			let name = &x.name;
+			let kind = Self::to_syntax_string(&x.kind);
+			format!(r##"ethabi::Param {{ name: "{}".to_owned(), kind: {} }}"##, name, kind).into()
+		}).collect::<Vec<syn::Ident>>();
+		let function_inputs = quote! { vec![ #(#function_inputs),* ] };
+
+		let function_outputs = &function.outputs.iter().map(|x| {
+			let name = &x.name;
+			let kind = Self::to_syntax_string(&x.kind);
+			format!(r##"ethabi::Param {{ name: "{}".to_owned(), kind: {} }}"##, name, kind).into()
+		}).collect::<Vec<syn::Ident>>();
+		let function_outputs = quote! { vec![ #(#function_outputs),* ] };
+
+		let function_constant = &function.constant;
+
+		quote! {
+			#[derive(Clone)]
+			pub struct #name {
+				function: ethabi::Function,
 			}
 
-			#output_call_impl
+			impl Default for #name {
+				fn default() -> Self {
+					#name {
+						function: ethabi::Function {
+							name: #function_name.to_owned(),
+							inputs: #function_inputs,
+							outputs: #function_outputs,
+							constant: #function_constant
+						}
+					}
+				}
+			}
+
+			impl #name {
+
+				pub fn input<#(#template_params),*>(&self, #(#params),*) -> ethabi::Bytes {
+					let v: Vec<ethabi::Token> = vec![#(#usage),*];
+					self.function.encode_input(&v).expect(super::INTERNAL_ERR)
+				}
+
+				#output_call_impl
+			}
+		}
+	}
+
+	fn normalize_path(relative_path: &str) -> Result<PathBuf> {
+		// workaround for https://github.com/rust-lang/rust/issues/43860
+		let cargo_toml_directory = env::var("CARGO_MANIFEST_DIR").chain_err(|| "Cannot find manifest file")?;
+		let mut path: PathBuf = cargo_toml_directory.into();
+		path.push(relative_path);
+		Ok(path)
+	}
+
+	fn to_syntax_string(param_type : &ethabi::ParamType) -> quote::Tokens {
+		match *param_type {
+			ParamType::Address => quote! { ethabi::ParamType::Address },
+			ParamType::Bytes => quote! { ethabi::ParamType::Address },
+			ParamType::Int(x) => quote! { ethabi::ParamType::Int(#x) },
+			ParamType::Uint(x) => quote! { ethabi::ParamType::Uint(#x) },
+			ParamType::Bool => quote! { ethabi::ParamType::Bool },
+			ParamType::String => quote! { ethabi::ParamType::String },
+			ParamType::Array(ref param_type) => {
+				let param_type_quote = Self::to_syntax_string(param_type);
+				quote! { ethabi::ParamType::Array(Box::new(#param_type_quote)) }
+			},
+			ParamType::FixedBytes(x) => quote! { ethabi::ParamType::FixedBytes(#x) },
+			ParamType::FixedArray(ref param_type, ref x) => {
+				let param_type_quote = Self::to_syntax_string(param_type);
+				quote! { ethabi::ParamType::FixedArray(Box::new(#param_type_quote), #x) }
+			}
+		}
+	}
+
+	fn rust_type(input: &ParamType) -> syn::Ident {
+		match *input {
+			ParamType::Address => "ethabi::Address".into(),
+			ParamType::Bytes => "ethabi::Bytes".into(),
+			ParamType::FixedBytes(32) => "ethabi::Hash".into(),
+			ParamType::FixedBytes(size) => format!("[u8; {}]", size).into(),
+			ParamType::Int(_) => "ethabi::Int".into(),
+			ParamType::Uint(_) => "ethabi::Uint".into(),
+			ParamType::Bool => "bool".into(),
+			ParamType::String => "String".into(),
+			ParamType::Array(ref kind) => format!("Vec<{}>", Self::rust_type(&*kind)).into(),
+			ParamType::FixedArray(ref kind, size) => format!("[{}; {}]", Self::rust_type(&*kind), size).into(),
+		}
+	}
+
+	fn template_param_type(input: &ParamType, index: usize) -> syn::Ident {
+		match *input {
+			ParamType::Address => format!("T{}: Into<ethabi::Address>", index).into(),
+			ParamType::Bytes => format!("T{}: Into<ethabi::Bytes>", index).into(),
+			ParamType::FixedBytes(32) => format!("T{}: Into<ethabi::Hash>", index).into(),
+			ParamType::FixedBytes(size) => format!("T{}: Into<[u8; {}]>", index, size).into(),
+			ParamType::Int(_) => format!("T{}: Into<ethabi::Int>", index).into(),
+			ParamType::Uint(_) => format!("T{}: Into<ethabi::Uint>", index).into(),
+			ParamType::Bool => format!("T{}: Into<bool>", index).into(),
+			ParamType::String => format!("T{}: Into<String>", index).into(),
+			ParamType::Array(ref kind) => format!("T{}: IntoIterator<Item = U{}>, U{}: Into<{}>", index, index, index, Self::rust_type(&*kind)).into(),
+			ParamType::FixedArray(ref kind, size) => format!("T{}: Into<[U{}; {}]>, U{}: Into<{}>", index, index, size, index, Self::rust_type(&*kind)).into(),
+		}
+	}
+
+	fn from_template_param(input: &ParamType, name: &syn::Ident) -> syn::Ident {
+		match *input {
+			ParamType::Array(_) => format!("{}.into_iter().map(Into::into).collect::<Vec<_>>()", name).into(),
+			ParamType::FixedArray(_, _) => format!("(Box::new({}.into()) as Box<[_]>).into_vec().into_iter().map(Into::into).collect::<Vec<_>>()", name).into(),
+			_ => format!("{}.into()", name).into(),
+		}
+	}
+
+	fn to_token(name: &syn::Ident, kind: &ParamType) -> quote::Tokens {
+		match *kind {
+			ParamType::Address => quote! { ethabi::Token::Address(#name) },
+			ParamType::Bytes => quote! { ethabi::Token::Bytes(#name) },
+			ParamType::FixedBytes(_) => quote! { ethabi::Token::FixedBytes(#name.to_vec()) },
+			ParamType::Int(_) => quote! { ethabi::Token::Int(#name) },
+			ParamType::Uint(_) => quote! { ethabi::Token::Uint(#name) },
+			ParamType::Bool => quote! { ethabi::Token::Bool(#name) },
+			ParamType::String => quote! { ethabi::Token::String(#name) },
+			ParamType::Array(ref kind) => {
+				let inner_name: syn::Ident = "inner".into();
+				let inner_loop = Self::to_token(&inner_name, kind);
+				quote! {
+					// note the double {{
+					{
+						let v = #name.into_iter().map(|#inner_name| #inner_loop).collect();
+						ethabi::Token::Array(v)
+					}
+				}
+			}
+			ParamType::FixedArray(ref kind, _) => {
+				let inner_name: syn::Ident = "inner".into();
+				let inner_loop = Self::to_token(&inner_name, kind);
+				quote! {
+					// note the double {{
+					{
+						let v = #name.into_iter().map(|#inner_name| #inner_loop).collect();
+						ethabi::Token::FixedArray(v)
+					}
+				}
+			},
+		}
+	}
+
+	fn from_token(kind: &ParamType, token: &syn::Ident) -> quote::Tokens {
+		match *kind {
+			ParamType::Address => quote! { #token.to_address().expect(super::INTERNAL_ERR) },
+			ParamType::Bytes => quote! { #token.to_bytes().expect(super::INTERNAL_ERR) },
+			ParamType::FixedBytes(size) => {
+				let size: syn::Ident = format!("{}", size).into();
+				quote! {
+					{
+						let mut result = [0u8; #size];
+						let v = #token.to_fixed_bytes().expect(super::INTERNAL_ERR);
+						result.copy_from_slice(&v);
+						result
+					}
+				}
+			},
+			ParamType::Int(_) => quote! { #token.to_int().expect(super::INTERNAL_ERR) },
+			ParamType::Uint(_) => quote! { #token.to_uint().expect(super::INTERNAL_ERR) },
+			ParamType::Bool => quote! { #token.to_bool().expect(super::INTERNAL_ERR) },
+			ParamType::String => quote! { #token.to_string().expect(super::INTERNAL_ERR) },
+			ParamType::Array(ref kind) => {
+				let inner: syn::Ident = "inner".into();
+				let inner_loop = Self::from_token(kind, &inner);
+				quote! {
+					#token.to_array().expect(super::INTERNAL_ERR).into_iter()
+						.map(|#inner| #inner_loop)
+						.collect()
+				}
+			},
+			ParamType::FixedArray(ref kind, size) => {
+				let inner: syn::Ident = "inner".into();
+				let inner_loop = Self::from_token(kind, &inner);
+				let to_array = vec![quote! { iter.next() }; size];
+				quote! {
+					{
+						let iter = #token.to_array().expect(super::INTERNAL_ERR).into_iter()
+							.map(|#inner| #inner_loop);
+						[#(#to_array),*]
+					}
+				}
+			},
 		}
 	}
 }

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethabi"
-version = "4.2.0"
+version = "4.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 homepage = "https://github.com/paritytech/ethabi"
 license = "MIT"

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethabi"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 homepage = "https://github.com/paritytech/ethabi"
 license = "MIT"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,3 +8,4 @@ ethabi = { path = "../ethabi" }
 ethabi-derive = { path = "../derive" }
 ethabi-contract = { path = "../contract" }
 rustc-hex = "1.0"
+futures = "0.1"

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -10,7 +10,7 @@ extern crate ethabi_derive;
 extern crate ethabi_contract;
 
 use_contract!(eip20, "Eip20", "../res/eip20.abi");
-use_contract_futures!(eip20_futures, "Eip20Futures", "../res/eip20.abi");
+use_contract_async!(eip20_async, "Eip20Async", "../res/eip20.abi");
 use_contract!(constructor, "Constructor", "../res/con.abi");
 use_contract!(validators, "Validators", "../res/Validators.abi");
 
@@ -126,27 +126,27 @@ mod tests {
 		let result = contract.functions().balance_of().call(address_param, &|data| {
 			assert_eq!(data, "70a082310000000000000000000000000000000000000000000000000000000000000000".from_hex().unwrap());
 			Ok("000000000000000000000000000000000000000000000000000000000036455b".from_hex().unwrap())
-        });
+		});
 		assert_eq!(result.unwrap().to_hex(), "000000000000000000000000000000000000000000000000000000000036455b");
 	}
 
 	#[test]
-	fn test_calling_function_future() {
-		use eip20_futures::Eip20Futures;
+	fn test_calling_function_async() {
+		use eip20_async::Eip20Async;
 		use futures::{Future, future};
 
-		let contract = Eip20Futures::default();
+		let contract = Eip20Async::default();
 		let address_param = [0u8; 20];
 		let functions = contract.functions(); // .balance_of() is moved
 
-		let result = functions.balance_of().call_future(address_param, &|data| {
+		let result = functions.balance_of().call_async(address_param, &|data| {
 			assert_eq!(data, "70a082310000000000000000000000000000000000000000000000000000000000000000".from_hex().unwrap());
 			Box::new(future::ok("000000000000000000000000000000000000000000000000000000000036455b".from_hex().unwrap()))
-        });
-		let result2 = functions.balance_of().call_future(address_param, &|data| {
+		});
+		let result2 = functions.balance_of().call_async(address_param, &|data| {
 			assert_eq!(data, "70a082310000000000000000000000000000000000000000000000000000000000000000".from_hex().unwrap());
 			Box::new(future::ok("000000000000000000000000000000000000000000000000000000000036455b".from_hex().unwrap()))
-        });
+		});
 		assert_eq!(result.wait().unwrap().to_hex(), "000000000000000000000000000000000000000000000000000000000036455b");
 		assert_eq!(result2.wait().unwrap().to_hex(), "000000000000000000000000000000000000000000000000000000000036455b");
 	}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -10,7 +10,7 @@ extern crate ethabi_derive;
 extern crate ethabi_contract;
 
 use_contract!(eip20, "Eip20", "../res/eip20.abi");
-use_contract_async!(eip20_async, "Eip20Async", "../res/eip20.abi");
+use_contract!(eip20_async, "Eip20Async", "../res/eip20.abi");
 use_contract!(constructor, "Constructor", "../res/con.abi");
 use_contract!(validators, "Validators", "../res/Validators.abi");
 
@@ -152,4 +152,3 @@ mod tests {
 	}
 
 }
-

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,16 +1,13 @@
 #![deny(warnings)]
 
 extern crate rustc_hex;
+extern crate futures;
 #[allow(unused_imports)]
 extern crate ethabi;
 #[macro_use]
 extern crate ethabi_derive;
 #[macro_use]
 extern crate ethabi_contract;
-
-extern crate futures;
-
-// include!("cc.rs");
 
 use_contract!(eip20, "Eip20", "../res/eip20.abi");
 use_contract_futures!(eip20_futures, "Eip20Futures", "../res/eip20.abi");


### PR DESCRIPTION
closes https://github.com/paritytech/ethabi/issues/64

Added another macro `use_contract_futures!()` that derives the contract with the extra `call_future` function. Refactored the code a little bit to separate macro config parsing from the implementation; and to allow the macro config to be shared between the functions.

@tomusdrw's comment mentioned returning `IntoFuture<>`; currently the method returns a `Future`. Let me know if I should change this.

Also, I imagine we could write integration tests with rust-web3?