### PR TITLE
Fixed invalid code generated by ethabi-derive when output type is a hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ version = "5.0.1"
 
 [[package]]
 name = "ethabi-derive"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "ethabi 5.0.1",
  "heck 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -122,7 +122,7 @@ version = "0.1.0"
 dependencies = [
  "ethabi 5.0.1",
  "ethabi-contract 5.0.1",
- "ethabi-derive 5.0.1",
+ "ethabi-derive 5.0.2",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethabi-derive"
-version = "5.0.1"
+version = "5.0.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 homepage = "https://github.com/paritytech/ethabi"
 license = "MIT"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -271,6 +271,14 @@ fn from_token(kind: &ParamType, token: &syn::Ident) -> quote::Tokens {
 	match *kind {
 		ParamType::Address => quote! { #token.to_address().expect(super::INTERNAL_ERR) },
 		ParamType::Bytes => quote! { #token.to_bytes().expect(super::INTERNAL_ERR) },
+		ParamType::FixedBytes(32) => quote! {
+			{
+				let mut result = [0u8; 32];
+				let v = #token.to_fixed_bytes().expect(super::INTERNAL_ERR);
+				result.copy_from_slice(&v);
+				ethabi::Hash::from(result)
+			}
+		},
 		ParamType::FixedBytes(size) => {
 			let size: syn::Ident = format!("{}", size).into();
 			quote! {

--- a/res/Operations.abi
+++ b/res/Operations.abi
@@ -1,0 +1,560 @@
+[
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "_client",
+				"type": "bytes32"
+			},
+			{
+				"name": "_newOwner",
+				"type": "address"
+			}
+		],
+		"name": "resetClientOwner",
+		"outputs": [],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "_client",
+				"type": "bytes32"
+			},
+			{
+				"name": "_release",
+				"type": "bytes32"
+			}
+		],
+		"name": "isLatest",
+		"outputs": [
+			{
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "_txid",
+				"type": "bytes32"
+			}
+		],
+		"name": "rejectTransaction",
+		"outputs": [],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "_newOwner",
+				"type": "address"
+			}
+		],
+		"name": "setOwner",
+		"outputs": [],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "_number",
+				"type": "uint32"
+			},
+			{
+				"name": "_name",
+				"type": "bytes32"
+			},
+			{
+				"name": "_hard",
+				"type": "bool"
+			},
+			{
+				"name": "_spec",
+				"type": "bytes32"
+			}
+		],
+		"name": "proposeFork",
+		"outputs": [],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "_client",
+				"type": "bytes32"
+			}
+		],
+		"name": "removeClient",
+		"outputs": [],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "_client",
+				"type": "bytes32"
+			},
+			{
+				"name": "_release",
+				"type": "bytes32"
+			}
+		],
+		"name": "release",
+		"outputs": [
+			{
+				"name": "o_forkBlock",
+				"type": "uint32"
+			},
+			{
+				"name": "o_track",
+				"type": "uint8"
+			},
+			{
+				"name": "o_semver",
+				"type": "uint24"
+			},
+			{
+				"name": "o_critical",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "_client",
+				"type": "bytes32"
+			},
+			{
+				"name": "_checksum",
+				"type": "bytes32"
+			}
+		],
+		"name": "build",
+		"outputs": [
+			{
+				"name": "o_release",
+				"type": "bytes32"
+			},
+			{
+				"name": "o_platform",
+				"type": "bytes32"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "rejectFork",
+		"outputs": [],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "",
+				"type": "bytes32"
+			}
+		],
+		"name": "client",
+		"outputs": [
+			{
+				"name": "owner",
+				"type": "address"
+			},
+			{
+				"name": "required",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "_newOwner",
+				"type": "address"
+			}
+		],
+		"name": "setClientOwner",
+		"outputs": [],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "",
+				"type": "uint32"
+			}
+		],
+		"name": "fork",
+		"outputs": [
+			{
+				"name": "name",
+				"type": "bytes32"
+			},
+			{
+				"name": "spec",
+				"type": "bytes32"
+			},
+			{
+				"name": "hard",
+				"type": "bool"
+			},
+			{
+				"name": "ratified",
+				"type": "bool"
+			},
+			{
+				"name": "requiredCount",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "_release",
+				"type": "bytes32"
+			},
+			{
+				"name": "_platform",
+				"type": "bytes32"
+			},
+			{
+				"name": "_checksum",
+				"type": "bytes32"
+			}
+		],
+		"name": "addChecksum",
+		"outputs": [],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "_txid",
+				"type": "bytes32"
+			}
+		],
+		"name": "confirmTransaction",
+		"outputs": [
+			{
+				"name": "txSuccess",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "",
+				"type": "bytes32"
+			}
+		],
+		"name": "proxy",
+		"outputs": [
+			{
+				"name": "requiredCount",
+				"type": "uint256"
+			},
+			{
+				"name": "to",
+				"type": "address"
+			},
+			{
+				"name": "data",
+				"type": "bytes"
+			},
+			{
+				"name": "value",
+				"type": "uint256"
+			},
+			{
+				"name": "gas",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "_client",
+				"type": "bytes32"
+			},
+			{
+				"name": "_owner",
+				"type": "address"
+			}
+		],
+		"name": "addClient",
+		"outputs": [],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "",
+				"type": "address"
+			}
+		],
+		"name": "clientOwner",
+		"outputs": [
+			{
+				"name": "",
+				"type": "bytes32"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "_txid",
+				"type": "bytes32"
+			},
+			{
+				"name": "_to",
+				"type": "address"
+			},
+			{
+				"name": "_data",
+				"type": "bytes"
+			},
+			{
+				"name": "_value",
+				"type": "uint256"
+			},
+			{
+				"name": "_gas",
+				"type": "uint256"
+			}
+		],
+		"name": "proposeTransaction",
+		"outputs": [
+			{
+				"name": "txSuccess",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "grandOwner",
+		"outputs": [
+			{
+				"name": "",
+				"type": "address"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "_release",
+				"type": "bytes32"
+			},
+			{
+				"name": "_forkBlock",
+				"type": "uint32"
+			},
+			{
+				"name": "_track",
+				"type": "uint8"
+			},
+			{
+				"name": "_semver",
+				"type": "uint24"
+			},
+			{
+				"name": "_critical",
+				"type": "bool"
+			}
+		],
+		"name": "addRelease",
+		"outputs": [],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "acceptFork",
+		"outputs": [],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "clientsRequired",
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint32"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "_client",
+				"type": "bytes32"
+			},
+			{
+				"name": "_release",
+				"type": "bytes32"
+			}
+		],
+		"name": "track",
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint8"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "_client",
+				"type": "bytes32"
+			},
+			{
+				"name": "_r",
+				"type": "bool"
+			}
+		],
+		"name": "setClientRequired",
+		"outputs": [],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "latestFork",
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint32"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "_client",
+				"type": "bytes32"
+			},
+			{
+				"name": "_track",
+				"type": "uint8"
+			}
+		],
+		"name": "latestInTrack",
+		"outputs": [
+			{
+				"name": "",
+				"type": "bytes32"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "_client",
+				"type": "bytes32"
+			},
+			{
+				"name": "_release",
+				"type": "bytes32"
+			},
+			{
+				"name": "_platform",
+				"type": "bytes32"
+			}
+		],
+		"name": "checksum",
+		"outputs": [
+			{
+				"name": "",
+				"type": "bytes32"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "proposedFork",
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint32"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	}
+]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -10,6 +10,7 @@ extern crate ethabi_contract;
 use_contract!(eip20, "Eip20", "../res/eip20.abi");
 use_contract!(constructor, "Constructor", "../res/con.abi");
 use_contract!(validators, "Validators", "../res/Validators.abi");
+use_contract!(operations, "Operations", "../res/Operations.abi");
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
added also a 'test' which is an abi file 'res/operations.abi'