### PR TITLE
Fix lenient encoding of big uint256 (pending: i256)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -214,12 +214,28 @@ mod tests {
 		assert_eq!(execute(command).unwrap(), expected);
 	}
 
-	// TODO: parsing negative values is not working
 	#[test]
-	#[ignore]
 	fn int_encode() {
-		let command = "ethabi encode paramas -v int256 -2 --lenient".split(" ");
+		let command = "ethabi encode params -v int256 100000000000 --lenient".split(" ");
+		let expected = "000000000000000000000000000000000000000000000000000000174876e800";
+		assert_eq!(execute(command).unwrap(), expected);
+	}
+
+	#[test]
+	fn int_encode_negative() {
+		let command = "ethabi encode params --lenient -v -- int256 -2".split(" ");
 		let expected = "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe";
+		assert_eq!(execute(command).unwrap(), expected);
+
+		let command = "ethabi encode params --lenient -v -v -- int256 -2 int256 -3".split(" ");
+		let expected = "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd";
+		assert_eq!(execute(command).unwrap(), expected);
+	}
+
+	#[test]
+	fn uint_encode() {
+		let command = "ethabi encode params -v uint256 100000000000 --lenient".split(" ");
+		let expected = "000000000000000000000000000000000000000000000000000000174876e800";
 		assert_eq!(execute(command).unwrap(), expected);
 	}
 

--- a/ethabi/src/token/lenient.rs
+++ b/ethabi/src/token/lenient.rs
@@ -1,6 +1,7 @@
 use token::{Tokenizer, StrictTokenizer};
-use util::{pad_u32, pad_i32};
-use errors::Error;
+use util::pad_i32;
+use errors::{Error, ErrorKind};
+use Uint;
 
 /// Tries to parse string as a token. Does not require string to clearly represent the value.
 pub struct LenientTokenizer;
@@ -32,8 +33,8 @@ impl Tokenizer for LenientTokenizer {
 			return result;
 		}
 
-		let uint = try!(u32::from_str_radix(value, 10));
-		Ok(pad_u32(uint))
+		let uint: Uint = Uint::from_dec_str(value).map_err(|_| ErrorKind::InvalidData)?;
+		Ok(uint.into())
 	}
 
 	fn tokenize_int(value: &str) -> Result<[u8; 32], Error> {


### PR DESCRIPTION
should fix #79

(Previous behaviour was to parse the input u256/i256 string as u32/i32 and then pad it to 256 bits; hence why it didn't work with big numbers as input. Now I'm trying to parse the input string as u256/i256 directly.)

- Fix lenient encoding of big u256
- Add test for lenient encoding of big u256
- Add test for lenient encoding of big i256. Didn't pass before; still doesn't pass. It looks like ethabi::Int and ethabi::Uint are both aliases to ethereum_types::U256 and so I don't know how to handle converting a string to a signed i256. Do we have anything in ethereum-types to convert from a string to a signed i256? Or is there a util function somewhere I could use? Any pointers? @debris 
- Un-ignore test for encoding negative i256 (I think we can close #2)