### PR TITLE
Fix derive for String params.

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -229,7 +229,7 @@ fn template_param_type(input: &ParamType, index: usize) -> quote::Tokens {
 		ParamType::Int(_) => quote! { #t_ident: Into<ethabi::Int> },
 		ParamType::Uint(_) => quote! { #t_ident: Into<ethabi::Uint> },
 		ParamType::Bool => quote! { #t_ident: Into<bool> },
-		ParamType::String => quote! { T{}: Into<String> },
+		ParamType::String => quote! { #t_ident: Into<String> },
 		ParamType::Array(ref kind) => {
 			let t = rust_type(&*kind);
 			quote! {

--- a/res/Validators.abi
+++ b/res/Validators.abi
@@ -68,5 +68,19 @@
         ],
         "name": "Changed",
         "type": "event"
+    },
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "name": "title",
+                "type": "string"
+            }
+        ],
+        "name": "setTitle",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
     }
 ]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -100,13 +100,17 @@ mod tests {
 
 		let functions = contract.functions();
 		let add_validators = functions.add_two_validators();
+		let set_title = functions.set_title();
 
 		let encoded_from_array = add_validators.input([first.clone(), second.clone()]);
 		let encoded_from_array_wrapped = add_validators.input([Wrapper(first), Wrapper(second)]);
+		let encoded_from_string = set_title.input("foo");
 
-		let expected = "7de33d2000000000000000000000000011111111111111111111111111111111111111110000000000000000000000002222222222222222222222222222222222222222".to_owned();
-		assert_eq!(expected, encoded_from_array.to_hex());
-		assert_eq!(expected, encoded_from_array_wrapped.to_hex());
+		let expected_array = "7de33d2000000000000000000000000011111111111111111111111111111111111111110000000000000000000000002222222222222222222222222222222222222222".to_owned();
+		let expected_string = "72910be000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003666f6f0000000000000000000000000000000000000000000000000000000000".to_owned();
+		assert_eq!(expected_array, encoded_from_array.to_hex());
+		assert_eq!(expected_array, encoded_from_array_wrapped.to_hex());
+		assert_eq!(expected_string, encoded_from_string.to_hex())
 	}
 
 	#[test]
@@ -140,6 +144,5 @@ mod tests {
         });
 		assert_eq!(result.unwrap(), "000000000000000000000000000000000000000000000000000000000036455b".into());
 	}
-
 }
 


### PR DESCRIPTION
Make `use_contract!` work for functions with string parameters.