### PR TITLE
Support internal parameter types

### DIFF
--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -32,7 +32,7 @@ mod param;
 mod signature;
 mod util;
 
-pub use param_type::ParamType;
+pub use param_type::{ParamModifier, ParamType};
 pub use constructor::Constructor;
 pub use contract::{Contract, Functions, Events};
 pub use token::Token;

--- a/ethabi/src/param_type/mod.rs
+++ b/ethabi/src/param_type/mod.rs
@@ -5,6 +5,6 @@ mod param_type;
 mod reader;
 mod writer;
 
-pub use self::param_type::ParamType;
+pub use self::param_type::{ParamModifier, ParamType};
 pub use self::writer::Writer;
 pub use self::reader::Reader;

--- a/ethabi/src/param_type/param_type.rs
+++ b/ethabi/src/param_type/param_type.rs
@@ -3,6 +3,21 @@
 use std::fmt;
 use super::Writer;
 
+/// Modifier for parameter types.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParamModifier {
+	/// The storage modifier associated with parameter types.
+	Storage,
+}
+
+impl fmt::Display for ParamModifier {
+	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+		match *self {
+			ParamModifier::Storage => "storage".fmt(fmt),
+		}
+	}
+}
+
 /// Function and event param types.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ParamType {

--- a/ethabi/src/param_type/reader.rs
+++ b/ethabi/src/param_type/reader.rs
@@ -1,4 +1,4 @@
-use {ParamType, Error, ErrorKind};
+use {ParamModifier, ParamType, Error, ErrorKind};
 
 /// Used to convert param type represented as a string to rust structure.
 pub struct Reader;
@@ -50,8 +50,27 @@ impl Reader {
 				let len = try!(usize::from_str_radix(&s[5..], 10));
 				ParamType::FixedBytes(len)
 			},
-			_ => {
-				return Err(ErrorKind::InvalidName(name.to_owned()).into());
+			ty => {
+				let mut parts = ty.split(" ");
+
+				let ty = match parts.next() {
+					Some(ty) => ty,
+					None => return Err(ErrorKind::InvalidName(ty.to_owned()).into()),
+				};
+
+				let mut mods = Vec::new();
+
+				while let Some(modifier) = parts.next() {
+					let modifier = match modifier {
+						"storage" => ParamModifier::Storage,
+						_ => return Err(ErrorKind::InvalidName(ty.to_owned()).into()),
+					};
+
+					mods.push(modifier);
+				}
+
+				// TODO: use some other param type that can actually do something useful?
+				ParamType::Bytes
 			}
 		};
 

--- a/res/test_internal_type.abi
+++ b/res/test_internal_type.abi
@@ -1,0 +1,13 @@
+[
+    {
+        "inputs": [
+            {
+                "name": "storage",
+                "type": "Storage storage"
+            }
+        ],
+        "name": "foo",
+        "outputs": [],
+        "type": "function"
+    }
+]

--- a/res/test_internal_type.abi
+++ b/res/test_internal_type.abi
@@ -3,7 +3,7 @@
         "inputs": [
             {
                 "name": "storage",
-                "type": "Storage storage"
+                "type": "Storage.Storage storage"
             }
         ],
         "name": "foo",

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -17,6 +17,7 @@ use_contract!(validators, "../res/Validators.abi");
 use_contract!(operations, "../res/Operations.abi");
 use_contract!(urlhint, "../res/urlhint.abi");
 use_contract!(test_rust_keywords, "../res/test_rust_keywords.abi");
+use_contract!(internal_types, "../res/test_internal_type.abi");
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This adds very simplistic support for internal types in function parameters.

"internal types" is probably the wrong name, but they are types like `data` below:

```solitude
library MyLib {
    struct Storage {
    }

    function doSomething(Storage storage data) public {
    }
}
```

I am not aware of a reasonable way to call these functions (e.g. it has to be done from another contract). So best would probably to skip these functions when generating ABIs in the future. For now this adds basic support for parsing them in case we want to do something useful with them in the future. We'll just have to be careful not to use these functions.