### PR TITLE
Avoid rust keyword in function inputs

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -380,7 +380,7 @@ fn input_names(inputs: &Vec<Param>) -> Vec<syn::Ident> {
 		.map(|(index, param)| if param.name.is_empty() {
 			syn::Ident::from(format!("param{}", index))
 		} else {
-			param.name.to_snake_case().into()
+			rust_variable(&param.name).into()
 		})
 		.collect()
 }
@@ -815,5 +815,16 @@ fn declare_functions_input_wrappers(function: &Function) -> quote::Tokens {
 				}
 			}
 		}
+	}
+}
+
+/// Convert input into a rust variable name.
+///
+/// Avoid using keywords by escaping them.
+fn rust_variable(name: &str) -> String {
+	// avoid keyword parameters
+	match name {
+		"self" => "_self".to_string(),
+		other => other.to_snake_case(),
 	}
 }

--- a/res/test_rust_keywords.abi
+++ b/res/test_rust_keywords.abi
@@ -1,0 +1,13 @@
+[
+    {
+        "inputs": [
+            {
+                "name": "self",
+                "type": "bool"
+            }
+        ],
+        "name": "foo",
+        "outputs": [],
+        "type": "function"
+    }
+]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -16,6 +16,7 @@ use_contract!(constructor, "Constructor", "../res/con.abi");
 use_contract!(validators, "Validators", "../res/Validators.abi");
 use_contract!(operations, "Operations", "../res/Operations.abi");
 use_contract!(urlhint, "UrlHint", "../res/urlhint.abi");
+use_contract!(test_rust_keywords, "RustKeywords", "../res/test_rust_keywords.abi");
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This adds escaping for the rust keyword `self` in function inputs. This otherwise causes a failure during code generation which is _very_ hard to debug.

It affects contracts that happen to use `self` as a parameter on one of its inputs.

There obviously are more keywords and context for which this might be a problem. But at least this is a start.