### PR TITLE
Simplify derive to remove unused wrapper structs

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! use_contract {
-	($module: ident, $name: expr, $path: expr) => {
+	($module: ident, $path: expr) => {
 		#[allow(dead_code)]
 		#[allow(missing_docs)]
 		#[allow(unused_imports)]
@@ -8,7 +8,7 @@ macro_rules! use_contract {
 		#[allow(unused_variables)]
 		pub mod $module {
 			#[derive(EthabiContract)]
-			#[ethabi_contract_options(name = $name, path = $path)]
+			#[ethabi_contract_options(path = $path)]
 			struct _Dummy;
 		}
 	}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -11,12 +11,12 @@ extern crate ethabi_derive;
 #[macro_use]
 extern crate ethabi_contract;
 
-use_contract!(eip20, "Eip20", "../res/eip20.abi");
-use_contract!(constructor, "Constructor", "../res/con.abi");
-use_contract!(validators, "Validators", "../res/Validators.abi");
-use_contract!(operations, "Operations", "../res/Operations.abi");
-use_contract!(urlhint, "UrlHint", "../res/urlhint.abi");
-use_contract!(test_rust_keywords, "RustKeywords", "../res/test_rust_keywords.abi");
+use_contract!(eip20, "../res/eip20.abi");
+use_contract!(constructor, "../res/con.abi");
+use_contract!(validators, "../res/Validators.abi");
+use_contract!(operations, "../res/Operations.abi");
+use_contract!(urlhint, "../res/urlhint.abi");
+use_contract!(test_rust_keywords, "../res/test_rust_keywords.abi");
 
 #[cfg(test)]
 mod tests {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -32,26 +32,15 @@ mod tests {
 	}
 
 	#[test]
-	fn should_be_cloneable() {
-		use validators::Validators;
-
-		let contract = Validators::default();
-		let _ = contract.clone();
-	}
-
-	#[test]
 	fn test_encoding_function_input_as_array() {
-		use validators::Validators;
+        use validators::functions;
 
-		let contract = Validators::default();
 		let first = [0x11u8; 20];
 		let second = [0x22u8; 20];
 
-		let functions = contract.functions();
-
-		let encoded_from_vec = functions.set_validators(vec![first.clone(), second.clone()]).encoded();
-		let encoded_from_vec_iter = functions.set_validators(vec![first.clone(), second.clone()].into_iter()).encoded();
-		let encoded_from_vec_wrapped = functions.set_validators(vec![Wrapper(first), Wrapper(second)]).encoded();
+		let encoded_from_vec = functions::set_validators(vec![first.clone(), second.clone()]).encoded();
+		let encoded_from_vec_iter = functions::set_validators(vec![first.clone(), second.clone()].into_iter()).encoded();
+		let encoded_from_vec_wrapped = functions::set_validators(vec![Wrapper(first), Wrapper(second)]).encoded();
 
 		let expected = "9300c9260000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000011111111111111111111111111111111111111110000000000000000000000002222222222222222222222222222222222222222".to_owned();
 		assert_eq!(expected, encoded_from_vec.to_hex());
@@ -65,14 +54,13 @@ mod tests {
 
 		// given
 
-		use eip20::Eip20;
-		let contract = Eip20::default();
+		use eip20;
 		let output = "000000000000000000000000000000000000000000000000000000000036455B".from_hex().unwrap();
 
 		// when
 
-		let decoded_output = contract.outputs().total_supply(&output).unwrap();
-		let decoded_output2 = contract.functions().total_supply().output(output).unwrap();
+		let decoded_output = eip20::outputs::total_supply(&output).unwrap();
+		let decoded_output2 = eip20::functions::total_supply().output(output).unwrap();
 
 		// then
 
@@ -83,16 +71,15 @@ mod tests {
 
 	#[test]
 	fn test_encoding_constructor_as_array() {
-		use validators::Validators;
+		use validators::constructor;
 
-		let contract = Validators::default();
 		let code = Vec::new();
 		let first = [0x11u8; 20];
 		let second = [0x22u8; 20];
 
-		let encoded_from_vec = contract.constructor(code.clone(), vec![first.clone(), second.clone()]).encoded();
-		let encoded_from_vec_iter = contract.constructor(code.clone(), vec![first.clone(), second.clone()].into_iter()).encoded();
-		let encoded_from_vec_wrapped = contract.constructor(code.clone(), vec![Wrapper(first), Wrapper(second)]).encoded();
+		let encoded_from_vec = constructor(code.clone(), vec![first.clone(), second.clone()]).encoded();
+		let encoded_from_vec_iter = constructor(code.clone(), vec![first.clone(), second.clone()].into_iter()).encoded();
+		let encoded_from_vec_wrapped = constructor(code.clone(), vec![Wrapper(first), Wrapper(second)]).encoded();
 
 		let expected = "0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000011111111111111111111111111111111111111110000000000000000000000002222222222222222222222222222222222222222".to_owned();
 		assert_eq!(expected, encoded_from_vec.to_hex());
@@ -102,16 +89,14 @@ mod tests {
 
 	#[test]
 	fn test_encoding_function_input_as_fixed_array() {
-		use validators::Validators;
+		use validators::functions;
 
-		let contract = Validators::default();
 		let first = [0x11u8; 20];
 		let second = [0x22u8; 20];
 
-		let functions = contract.functions();
-		let encoded_from_array = functions.add_two_validators([first.clone(), second.clone()]).encoded();
-		let encoded_from_array_wrapped = functions.add_two_validators([Wrapper(first), Wrapper(second)]).encoded();
-		let encoded_from_string = functions.set_title("foo").encoded();
+		let encoded_from_array = functions::add_two_validators([first.clone(), second.clone()]).encoded();
+		let encoded_from_array_wrapped = functions::add_two_validators([Wrapper(first), Wrapper(second)]).encoded();
+		let encoded_from_string = functions::set_title("foo").encoded();
 
 		let expected_array = "7de33d2000000000000000000000000011111111111111111111111111111111111111110000000000000000000000002222222222222222222222222222222222222222".to_owned();
 		let expected_string = "72910be000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003666f6f0000000000000000000000000000000000000000000000000000000000".to_owned();
@@ -122,21 +107,20 @@ mod tests {
 
 	#[test]
 	fn encoding_input_works() {
-		use eip20::Eip20;
+		use eip20;
 
 		let expected = "dd62ed3e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000101010101010101010101010101010101010101".to_owned();
-		let contract = Eip20::default();
 		let owner = [0u8; 20];
 		let spender = [1u8; 20];
-		let encoded = contract.functions().allowance(owner, spender).encoded();
+		let encoded = eip20::functions::allowance(owner, spender).encoded();
 		// 4 bytes signature + 2 * 32 bytes for params
 		assert_eq!(encoded.to_hex(), expected);
 
 		let from: Address = [2u8; 20].into();
 		let to: Address = [3u8; 20].into();
 		let to2: Address = [4u8; 20].into();
-		let _filter = contract.events().transfer().create_filter(from, vec![to, to2]);
-		let _filter = contract.events().transfer().create_filter(None, None);
+		let _filter = eip20::events::transfer().create_filter(from, vec![to, to2]);
+		let _filter = eip20::events::transfer().create_filter(None, None);
 	}
 }
 


### PR DESCRIPTION
This gets rid of the struct that currently doesn't do anything.

You can see the difference in `tests/src/lib.rs`. There's no need to store a local variable called `contract`.

This also simplifies the `use_contract` macro, which no longer needs a `name` variable. All though I've not incorporated this change here since we use [our own macro](https://github.com/PrimaBlock/parables/blob/master/testing/macros.rs) in parables.

For me, this makes tests cleaner.