### PR TITLE
Introduce LogFilter trait to simplify filtering APIs

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -647,20 +647,20 @@ fn declare_events(event: &Event) -> quote::Tokens {
 
 		impl LogFilter for #name {
 			/// Create a default topic filter that matches any messages.
-			fn match_any(&self) -> ethabi::TopicFilter {
-				self.create_filter(#(#any_params),*)
+			fn wildcard_filter(&self) -> ethabi::TopicFilter {
+				self.filter(#(#any_params),*)
 			}
 		}
 
 		impl #name {
 			/// Creates topic filter.
-			pub fn create_filter<#(#template_params),*>(&self, #(#params),*) -> ethabi::TopicFilter {
+			pub fn filter<#(#template_params),*>(&self, #(#params),*) -> ethabi::TopicFilter {
 				let raw = ethabi::RawTopicFilter {
 					#(#to_filter)*
 					..Default::default()
 				};
 
-				self.event.create_filter(raw).expect(super::INTERNAL_ERR)
+				self.event.filter(raw).expect(super::INTERNAL_ERR)
 			}
 		}
 	}

--- a/ethabi/src/event.rs
+++ b/ethabi/src/event.rs
@@ -49,7 +49,7 @@ impl Event {
 	}
 
 	/// Creates topic filter
-	pub fn create_filter(&self, raw: RawTopicFilter) -> Result<TopicFilter> {
+	pub fn filter(&self, raw: RawTopicFilter) -> Result<TopicFilter> {
 		fn convert_token(token: Token, kind: &ParamType) -> Result<Hash> {
 			if !token.type_check(kind) {
 				return Err(ErrorKind::InvalidData.into());

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -42,7 +42,7 @@ pub use decoder::decode;
 pub use filter::{Topic, TopicFilter, RawTopicFilter};
 pub use function::Function;
 pub use param::Param;
-pub use log::{Log, RawLog, LogParam, ParseLog};
+pub use log::{Log, RawLog, LogParam, ParseLog, LogFilter};
 pub use event::Event;
 pub use event_param::EventParam;
 

--- a/ethabi/src/log.rs
+++ b/ethabi/src/log.rs
@@ -1,4 +1,10 @@
-use {Hash, Token, Bytes, Result};
+use {Hash, Token, Bytes, Result, TopicFilter};
+
+/// Common filtering functions that are available for any event.
+pub trait LogFilter {
+	/// Match any log parameters.
+	fn match_any(&self) -> TopicFilter;
+}
 
 /// trait common to things (events) that have an associated `Log` type
 /// that can be parsed from a `RawLog`

--- a/ethabi/src/log.rs
+++ b/ethabi/src/log.rs
@@ -3,7 +3,7 @@ use {Hash, Token, Bytes, Result, TopicFilter};
 /// Common filtering functions that are available for any event.
 pub trait LogFilter {
 	/// Match any log parameters.
-	fn match_any(&self) -> TopicFilter;
+	fn wildcard_filter(&self) -> TopicFilter;
 }
 
 /// trait common to things (events) that have an associated `Log` type

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -120,10 +120,10 @@ mod tests {
 		let from: Address = [2u8; 20].into();
 		let to: Address = [3u8; 20].into();
 		let to2: Address = [4u8; 20].into();
-		let _filter = eip20::events::transfer().create_filter(from, vec![to, to2]);
-		let match_any = eip20::events::transfer().create_filter(None, None);
-		let match_any_sugared = eip20::events::transfer().match_any();
-		assert_eq!(match_any, match_any_sugared);
+		let _filter = eip20::events::transfer().filter(from, vec![to, to2]);
+		let wildcard_filter = eip20::events::transfer().filter(None, None);
+		let wildcard_filter_sugared = eip20::events::transfer().wildcard_filter();
+		assert_eq!(wildcard_filter, wildcard_filter_sugared);
 	}
 }
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -108,6 +108,7 @@ mod tests {
 	#[test]
 	fn encoding_input_works() {
 		use eip20;
+		use ethabi::LogFilter;
 
 		let expected = "dd62ed3e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000101010101010101010101010101010101010101".to_owned();
 		let owner = [0u8; 20];
@@ -120,7 +121,9 @@ mod tests {
 		let to: Address = [3u8; 20].into();
 		let to2: Address = [4u8; 20].into();
 		let _filter = eip20::events::transfer().create_filter(from, vec![to, to2]);
-		let _filter = eip20::events::transfer().create_filter(None, None);
+		let match_any = eip20::events::transfer().create_filter(None, None);
+		let match_any_sugared = eip20::events::transfer().match_any();
+		assert_eq!(match_any, match_any_sugared);
 	}
 }
 


### PR DESCRIPTION
This simplifies writing APIs that uses the log abstraction and just wants "everything" without filtering.

You can see an example of it here:
https://github.com/PrimaBlock/parables/commit/0410483fa901d506273572edcd3ae3a76a3e4e0b#diff-1e74411566a577ec5675e59bf0bff74fR68

There's no longer a need to call `create_filter` with a ton of `Topic::Any` (or `None`). Instead we can generically make use of `LogFilter::match_any`.