### PR TITLE
improve error message when trying to decode empty bytes

### DIFF
--- a/ethabi/src/decoder.rs
+++ b/ethabi/src/decoder.rs
@@ -36,6 +36,10 @@ fn as_bool(slice: &[u8; 32]) -> Result<bool, Error> {
 
 /// Decodes ABI compliant vector of bytes into vector of tokens described by types param.
 pub fn decode(types: &[ParamType], data: &[u8]) -> Result<Vec<Token>, Error> {
+    let is_empty_bytes_valid_encoding = types.iter().all(|t| t.is_empty_bytes_valid_encoding());
+    if !is_empty_bytes_valid_encoding && data.len() == 0 {
+        bail!("please ensure the contract and method you're calling exist! failed to decode empty bytes. if you're using jsonrpc this is likely due to jsonrpc returning `0x` in case contract or method don't exist");
+    }
 	let slices = slice_data(data)?;
 	let mut tokens = vec![];
 	let mut offset = 0;

--- a/ethabi/src/decoder.rs
+++ b/ethabi/src/decoder.rs
@@ -479,5 +479,25 @@ mod tests {
 		let decoded = decode(&[ParamType::String], &encoded).unwrap();
 		assert_eq!(decoded, expected);
 	}
+
+	#[test]
+	fn decode_from_empty_byte_slice() {
+        // these can NOT be decoded from empty byte slice
+        assert!(decode(&[ParamType::Address], &[]).is_err());
+        assert!(decode(&[ParamType::Bytes], &[]).is_err());
+        assert!(decode(&[ParamType::Int(0)], &[]).is_err());
+        assert!(decode(&[ParamType::Int(1)], &[]).is_err());
+        assert!(decode(&[ParamType::Int(0)], &[]).is_err());
+        assert!(decode(&[ParamType::Int(1)], &[]).is_err());
+        assert!(decode(&[ParamType::Bool], &[]).is_err());
+        assert!(decode(&[ParamType::String], &[]).is_err());
+        assert!(decode(&[ParamType::Array(Box::new(ParamType::Bool))], &[]).is_err());
+        assert!(decode(&[ParamType::FixedBytes(1)], &[]).is_err());
+        assert!(decode(&[ParamType::FixedArray(Box::new(ParamType::Bool), 1)], &[]).is_err());
+
+        // these are the only ones that can be decoded from empty byte slice
+        assert!(decode(&[ParamType::FixedBytes(0)], &[]).is_ok());
+        assert!(decode(&[ParamType::FixedArray(Box::new(ParamType::Bool), 0)], &[]).is_ok());
+	}
 }
 

--- a/ethabi/src/param_type/param_type.rs
+++ b/ethabi/src/param_type/param_type.rs
@@ -32,6 +32,18 @@ impl fmt::Display for ParamType {
 	}
 }
 
+impl ParamType {
+    /// returns whether a zero length byte slice (`0x`) is
+    /// a valid encoded form of this param type
+    pub fn is_empty_bytes_valid_encoding(&self) -> bool {
+        match self {
+            ParamType::FixedBytes(len) => *len == 0,
+            ParamType::FixedArray(_, len) => *len == 0,
+            _ => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 	use ParamType;

--- a/ethabi/src/param_type/param_type.rs
+++ b/ethabi/src/param_type/param_type.rs
@@ -12,7 +12,7 @@ pub enum ParamType {
 	Bytes,
 	/// Signed integer.
 	Int(usize),
-	/// Unisgned integer.
+	/// Unsigned integer.
 	Uint(usize),
 	/// Boolean.
 	Bool,


### PR DESCRIPTION
as discussed in bridge riot. jsonrpc responds with result `0x` in case contract or method don't exist. ethabi fails with `Cannot decode {type}` in that case which suggests a problem different from the actual problem.

did experiments and found out that the only ethabi types that can be decoded from empty bytes are the "nonsense" types `FixedArray` and `FixedBytes` with length `0`