### PR TITLE
Fix encode array

### DIFF
--- a/ethabi/src/token/mod.rs
+++ b/ethabi/src/token/mod.rs
@@ -78,6 +78,10 @@ pub trait Tokenizer {
 			}
 		}
 
+		if ignore {
+			return Err(ErrorKind::InvalidData.into());
+		}
+
 		Ok(result)
 	}
 

--- a/ethabi/src/token/mod.rs
+++ b/ethabi/src/token/mod.rs
@@ -106,3 +106,16 @@ pub trait Tokenizer {
 	/// Tries to parse a value as signed integer.
 	fn tokenize_int(value: &str) -> Result<[u8; 32], Error>;
 }
+
+#[cfg(test)]
+mod test {
+	use super::{LenientTokenizer, Tokenizer, ParamType};
+	#[test]
+	fn single_quoted_in_array_must_error() {
+		assert!(LenientTokenizer::tokenize_array("[1,\"0,false]", &ParamType::Bool).is_err());
+		assert!(LenientTokenizer::tokenize_array("[false\"]", &ParamType::Bool).is_err());
+		assert!(LenientTokenizer::tokenize_array("[1,false\"]", &ParamType::Bool).is_err());
+		assert!(LenientTokenizer::tokenize_array("[1,\"0\",false]", &ParamType::Bool).is_err());
+		assert!(LenientTokenizer::tokenize_array("[1,0]", &ParamType::Bool).is_ok());
+	}
+}


### PR DESCRIPTION
In the encode array, everything after the single quote is ignored.:

```bash
$ ethabi encode params -v bool[] '[false"]'
00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000
```

```bash
$ ethabi encode params -v bool[] '[1,false"]'
000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001
```

```bash
$ ethabi encode params -v bool[] '[1,0,"false]' 
0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000
```

```bash
$ ethabi encode params -v bool[] '[1,"0,false]' 
000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001
```
I looked at the parsing process of the `tokenize_array` method. I think it should handle the single quoted data here and return invalid data error.