### PR TITLE
Derive Clone for RawLog, LogParam and Log

### DIFF
--- a/ethabi/src/log.rs
+++ b/ethabi/src/log.rs
@@ -18,7 +18,7 @@ pub trait ParseLog {
 }
 
 /// Ethereum log.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct RawLog {
 	/// Indexed event params are represented as log topics.
 	pub topics: Vec<Hash>,
@@ -36,7 +36,7 @@ impl From<(Vec<Hash>, Bytes)> for RawLog {
 }
 
 /// Decoded log param.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct LogParam {
 	/// Decoded log name.
 	pub name: String,
@@ -45,7 +45,7 @@ pub struct LogParam {
 }
 
 /// Decoded log.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Log {
 	/// Log params.
 	pub params: Vec<LogParam>,


### PR DESCRIPTION
I've added a derive `Clone` to `RawLog`, `LogParam` and `Log`, because sometimes it's beneficial to be able to clone them. One example of a code that would be improved by `Clone` in `RawLog` can be found [here](https://github.com/fluencelabs/fluence/blob/d5afb767ace989d2e9ffb692f608e79cddb15c96/cli/src/publisher.rs#L112-L117). I'll provide simplified version here:
```rust
use contract::events::app_deployed::parse_log as parse_deployed;
use contract::events::app_enqueued::parse_log as parse_enqueued;

|log: web3::types::Log| {
    let raw = || ethabi::RawLog::from((log.topics.clone(), log.data.0.clone()));

    let app_id = parse_deployed(raw());
    let app_id = app_id.or(parse_enqueued(raw());
    ...
}
```

In this example, closure has to operate on `web3::types::Log` to be able to clone it's fields. If clone would be available, it could operate directly on `RawLogs` and resulting code will be more concise:
```rust
use contract::events::app_deployed::parse_log as parse_deployed;
use contract::events::app_enqueued::parse_log as parse_enqueued;

|log: ethabi::RawLog| {
    let app_id = parse_deployed(log.clone());
    let app_id = app_id.or(parse_enqueued(log.clone());
    ...
}
```

Please, let me know if I should write some tests on that change. 