### PR TITLE
 Mark `contract::events::event_name::event()` as public

### DIFF
--- a/derive/src/event.rs
+++ b/derive/src/event.rs
@@ -154,7 +154,7 @@ impl Event {
 				use ethabi;
 				use super::INTERNAL_ERR;
 
-				fn event() -> ethabi::Event {
+				pub fn event() -> ethabi::Event {
 					ethabi::Event {
 						name: #name_as_string.into(),
 						inputs: #recreate_inputs_quote,
@@ -227,7 +227,7 @@ mod tests {
 				use ethabi;
 				use super::INTERNAL_ERR;
 
-				fn event() -> ethabi::Event {
+				pub fn event() -> ethabi::Event {
 					ethabi::Event {
 						name: "Hello".into(),
 						inputs: vec![],
@@ -279,7 +279,7 @@ mod tests {
 				use ethabi;
 				use super::INTERNAL_ERR;
 
-				fn event() -> ethabi::Event {
+				pub fn event() -> ethabi::Event {
 					ethabi::Event {
 						name: "One".into(),
 						inputs: vec![ethabi::EventParam {


### PR DESCRIPTION
It could be used to access methods of the `Event`, for example `signature`, to filter logs manually.

I'm not sure about other `Event` methods though, because main ones `filter` and `parse_log` are already covered in macro, so maybe it would make more sense to expose `signature` directly in generated methods, e.g.:
```rust
quote! {
    pub mod #name {
        use ethabi;
        use super::INTERNAL_ERR;

        fn event() -> ethabi::Event {
            ethabi::Event {
                name: #name_as_string.into(),
                inputs: #recreate_inputs_quote,
                anonymous: #anonymous,
            }
        }

        pub fn signature() -> ethabi::Hash {
            event().signature()
        }

        ...
    }
}
```

Please let me know, if I should change the code to expose just `signature`. Also, I'm not sure if I should change some other tests or maybe write a new one :)