### PR TITLE
Handle multiple events with the same name in one contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,7 @@ serde_derive = "1.0"
 docopt = "1.0"
 ethabi = { version = "8.0.0", path = "../ethabi" }
 error-chain = { version = "0.12.1", default-features = false }
+tiny-keccak = "1.0"
 
 [features]
 backtrace = ["error-chain/backtrace"]

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -2,6 +2,7 @@
 
 use std::io;
 use {ethabi, docopt, hex};
+use ethabi::Hash;
 
 error_chain! {
 	links {
@@ -12,5 +13,17 @@ error_chain! {
 		Io(io::Error);
 		Docopt(docopt::Error);
 		Hex(hex::FromHexError);
+	}
+
+	errors {
+		InvalidSignature(signature: Hash) {
+			description("Invalid signature"),
+			display("Invalid signature `{}`", signature),
+		}
+
+		AmbiguousEventName(name: String) {
+			description("More than one event found for name, try providing the full signature"),
+			display("Ambiguous event name `{}`", name),
+		}
 	}
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -213,7 +213,7 @@ fn hash_signature(sig: &str) -> Hash {
     sponge.update(&data);
     sponge.finalize(&mut result);
 
-    // This was deprecated but the replacement seems to not be availible.
+    // This was deprecated but the replacement seems to not be available.
     #[allow(deprecated)]
     Hash::from_slice(&result)
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -232,9 +232,6 @@ fn hash_signature(sig: &str) -> Hash {
     let mut sponge = Keccak::new_keccak256();
     sponge.update(&data);
     sponge.finalize(&mut result);
-
-    // This was deprecated but the replacement seems to not be available.
-    #[allow(deprecated)]
     Hash::from_slice(&result)
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -114,14 +114,14 @@ fn load_event(path: &str, name_or_signature: &str) -> Result<Event, Error> {
 		Some(params_start) => {
 			let name = &name_or_signature[..params_start];
 			let signature = hash_signature(name_or_signature);
-			contract.event(name)?.iter().find(|event|
+			contract.events_by_name(name)?.iter().find(|event|
 				event.signature() == signature
 			).cloned().ok_or(ErrorKind::InvalidSignature(signature).into())
 		}
 
 		// It's a name.
 		None => {
-			let events = contract.event(name_or_signature)?;
+			let events = contract.events_by_name(name_or_signature)?;
 			match events.len() {
 				0 => unreachable!(),
 				1 => Ok(events[0].clone()),

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -81,8 +81,16 @@ impl Contract {
 		self.functions.get(name).ok_or_else(|| ErrorKind::InvalidName(name.to_owned()).into())
 	}
 
+	/// Get the contract event named `name`, the first if there are multiple.
+	pub fn event(&self, name: &str) -> errors::Result<&Event> {
+		self.events.get(name).into_iter()
+							.flatten()
+							.next()
+							.ok_or_else(|| ErrorKind::InvalidName(name.to_owned()).into())
+	}
+
 	/// Get all contract events named `name`.
-	pub fn event(&self, name: &str) -> errors::Result<&Vec<Event>> {
+	pub fn events_by_name(&self, name: &str) -> errors::Result<&Vec<Event>> {
 		self.events.get(name)
 					.ok_or_else(|| ErrorKind::InvalidName(name.to_owned()).into())
 	}

--- a/ethabi/src/errors.rs
+++ b/ethabi/src/errors.rs
@@ -3,7 +3,6 @@
 
 use std::{num, string};
 use {serde_json, hex};
-use Hash;
 
 error_chain! {
 	foreign_links {
@@ -22,11 +21,6 @@ error_chain! {
 		InvalidData {
 			description("Invalid data"),
 			display("Invalid data"),
-		}
-
-		InvalidSignature(signature: Hash) {
-			description("Invalid signature"),
-			display("Invalid signature `{}`", signature),
 		}
 	}
 }

--- a/ethabi/src/errors.rs
+++ b/ethabi/src/errors.rs
@@ -3,6 +3,7 @@
 
 use std::{num, string};
 use {serde_json, hex};
+use Hash;
 
 error_chain! {
 	foreign_links {
@@ -21,6 +22,11 @@ error_chain! {
 		InvalidData {
 			description("Invalid data"),
 			display("Invalid data"),
+		}
+
+		InvalidSignature(signature: Hash) {
+			description("Invalid signature"),
+			display("Invalid signature `{}`", signature),
 		}
 	}
 }


### PR DESCRIPTION
By indexing the events by signature instead of name. We should somehow do the same for functions since currently they are also indexed by name, but functions don't have a `signature()` method available, so I'm not sure what to do there. A possible approach would be to to not use a map at all and use linear search on a vector.

This is a breaking change and will require a major release.