### PR TITLE
Fix for use in edition 2018 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ version = "8.0.0"
 dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -151,7 +151,7 @@ dependencies = [
  "ethabi 8.0.0",
  "ethabi-contract 8.0.0",
  "ethabi-derive 8.0.0",
- "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -223,19 +223,19 @@ dependencies = [
 
 [[package]]
 name = "hex-literal"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hex-literal-impl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-hack 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-literal-impl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "hex-literal-impl"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro-hack 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -340,14 +340,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro-hack-impl 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro-hack"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -355,11 +347,6 @@ dependencies = [
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "proc-macro-hack-impl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
@@ -580,8 +567,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
-"checksum hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4da5f0e01bd8a71a224a4eedecaacfcabda388dbb7a80faf04d3514287572d95"
-"checksum hex-literal-impl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1d340b6514f232f6db1bd16db65302a5278a04fef9ce867cb932e7e5fa21130a"
+"checksum hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3da68162fdd2147e66682e78e729bd77f93b4c99656db058c5782d8c6b6225a"
+"checksum hex-literal-impl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06095d08c7c05760f11a071b3e1d4c5b723761c01bd8d7201c30a9536668a612"
 "checksum impl-codec 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2050d823639fbeae26b2b5ba09aca8907793117324858070ade0673c49f793b"
 "checksum impl-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f39b9963cf5f12fcc4ae4b30a6927ed67d6b4ea4cbe7d17a41131163b401303b"
 "checksum impl-serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d26be4b97d738552ea423f76c4f681012ff06c3fa36fa968656b3679f60b4a1"
@@ -595,9 +582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum paste 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4a4a1c555c6505821f9d58b8779d0f630a6b7e4e1be24ba718610acf01fa79"
 "checksum paste-impl 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "26e796e623b8b257215f27e6c80a5478856cae305f5b59810ff9acdaa34570e6"
 "checksum primitive-types 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2288eb2a39386c4bc817974cc413afe173010dc80e470fcb1e9a35580869f024"
-"checksum proc-macro-hack 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ba8d4f9257b85eb6cdf13f055cea3190520aab1409ca2ab43493ea4820c25f0"
 "checksum proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "982a35d1194084ba319d65c4a68d24ca28f5fdb5b8bc20899e4eef8641ea5178"
-"checksum proc-macro-hack-impl 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5cb6f960ad471404618e9817c0e5d10b1ae74cfdf01fab89ea0641fe7fb2892"
 "checksum proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "ffe022fb8c8bd254524b0b3305906c1921fa37a84a644e29079a9e62200c3901"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -122,7 +122,7 @@ version = "8.0.0"
 dependencies = [
  "docopt 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethabi 8.0.0",
+ "ethabi 8.0.1",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -131,13 +131,13 @@ dependencies = [
 
 [[package]]
 name = "ethabi-contract"
-version = "8.0.0"
+version = "8.0.1"
 
 [[package]]
 name = "ethabi-derive"
 version = "8.0.0"
 dependencies = [
- "ethabi 8.0.0",
+ "ethabi 8.0.1",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -146,10 +146,10 @@ dependencies = [
 
 [[package]]
 name = "ethabi-tests"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
- "ethabi 8.0.0",
- "ethabi-contract 8.0.0",
+ "ethabi 8.0.1",
+ "ethabi-contract 8.0.1",
  "ethabi-derive 8.0.0",
  "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethabi-contract"
-version = "8.0.0"
+version = "8.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 homepage = "https://github.com/paritytech/ethabi"
 license = "MIT/Apache-2.0"

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -7,7 +7,7 @@ macro_rules! use_contract {
 		#[allow(unused_mut)]
 		#[allow(unused_variables)]
 		pub mod $module {
-			#[derive(EthabiContract)]
+			#[derive(ethabi_derive::EthabiContract)]
 			#[ethabi_contract_options(path = $path)]
 			struct _Dummy;
 		}

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -17,7 +17,7 @@ error-chain = { version = "0.12", default-features = false }
 ethereum-types = "0.6.0"
 
 [dev-dependencies]
-hex-literal = "0.1.1"
+hex-literal = "0.2.0"
 paste = "0.1.5"
 
 [features]

--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethabi"
-version = "8.0.0"
+version = "8.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 homepage = "https://github.com/paritytech/ethabi"
 license = "MIT/Apache-2.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethabi-tests"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["debris <marek.kotewicz@gmail.com>"]
 
 [dependencies]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ethabi-tests"
 version = "0.1.1"
 authors = ["debris <marek.kotewicz@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 ethabi = { path = "../ethabi" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,4 +8,4 @@ ethabi = { path = "../ethabi" }
 ethabi-derive = { path = "../derive" }
 ethabi-contract = { path = "../contract" }
 rustc-hex = "2.0"
-hex-literal = "0.1.1"
+hex-literal = "0.2.0"

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -7,8 +7,6 @@
 extern crate rustc_hex;
 extern crate ethabi;
 #[macro_use]
-extern crate ethabi_derive;
-#[macro_use]
 extern crate ethabi_contract;
 #[cfg(test)]
 #[macro_use]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -4,13 +4,7 @@
 #![deny(dead_code)]
 #![deny(unused_imports)]
 
-extern crate rustc_hex;
-extern crate ethabi;
-#[macro_use]
-extern crate ethabi_contract;
-#[cfg(test)]
-#[macro_use]
-extern crate hex_literal;
+use ethabi_contract::use_contract;
 
 use_contract!(eip20, "../res/eip20.abi");
 use_contract!(constructor, "../res/constructor.abi");
@@ -23,6 +17,8 @@ use_contract!(test_rust_keywords, "../res/test_rust_keywords.abi");
 mod tests {
 	use rustc_hex::ToHex;
 	use ethabi::{Address, Uint};
+	use hex_literal::hex;
+	use crate::{validators, eip20};
 
 	struct Wrapper([u8; 20]);
 
@@ -55,7 +51,6 @@ mod tests {
 
 		// given
 
-		use eip20;
 		let output = hex!("000000000000000000000000000000000000000000000000000000000036455B").to_vec();
 
 		// when
@@ -105,8 +100,6 @@ mod tests {
 
 	#[test]
 	fn encoding_input_works() {
-		use eip20;
-
 		let expected = "dd62ed3e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000101010101010101010101010101010101010101".to_owned();
 		let owner = [0u8; 20];
 		let spender = [1u8; 20];


### PR DESCRIPTION
Also fixes test compilation error by upgrading hex-literal.