### PR TITLE
Add support for overloaded contract functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+### Changed
+- Add support for overloaded contract functions (PR #166)
 
 ## [10.0.0] - 2020-01-08
 ### Changed

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Ethereum ABI coder.
   Copyright 2016-2017 Parity Technologies (UK) Limited
 
 Usage:
-    ethabi encode function <abi-path> <function-name> [-p <param>]... [-l | --lenient]
+    ethabi encode function <abi-path> <function-name-or-signature> [-p <param>]... [-l | --lenient]
     ethabi encode params [-v <type> <param>]... [-l | --lenient]
-    ethabi decode function <abi-path> <function-name> <data>
+    ethabi decode function <abi-path> <function-name-or-signature> <data>
     ethabi decode params [-t <type>]... <data>
-    ethabi decode log <abi-path> <event-name> [-l <topic>]... <data>
+    ethabi decode log <abi-path> <event-name-or-signature> [-l <topic>]... <data>
     ethabi -h | --help
 
 Options:
@@ -106,6 +106,67 @@ ethabi encode function examples/test.json foo -p 1
 ```
 
 > 455575780000000000000000000000000000000000000000000000000000000000000001
+
+--
+
+```
+ethabi encode function examples/test.json foo(bool) -p 1
+```
+
+```json
+[{
+	"type":"function",
+	"inputs": [{
+		"name":"a",
+		"type":"bool"
+	}],
+	"name":"foo",
+	"outputs": []
+}]
+```
+
+> 455575780000000000000000000000000000000000000000000000000000000000000001
+
+--
+
+```
+ethabi encode function examples/test.json bar(bool) -p 1
+```
+
+```json
+[{
+	"type":"function",
+	"inputs": [{
+		"name":"a",
+		"type":"bool"
+	}],
+	"name":"foo",
+	"outputs": []
+}]
+```
+
+> 6fae94120000000000000000000000000000000000000000000000000000000000000001
+
+--
+
+```
+ethabi encode function examples/test.json bar(string):(uint256) -p 1
+```
+
+```json
+[{
+	"type":"function",
+	"inputs": [{
+		"type":"string"
+	}],
+	"name":"foo",
+	"outputs": [{
+		"type": "uint256"
+	}]
+}]
+```
+
+> d473a8ed000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000013100000000000000000000000000000000000000000000000000000000000000
 
 --
 

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -24,5 +24,16 @@ error_chain! {
 			description("More than one event found for name, try providing the full signature"),
 			display("Ambiguous event name `{}`", name),
 		}
+
+		InvalidFunctionSignature(signature: String) {
+			description("Invalid function signature"),
+			display("Invalid function signature `{}`", signature),
+		}
+
+		AmbiguousFunctionName(name: String) {
+			description("More than one function found for name, try providing the full signature"),
+			display("Ambiguous function name `{}`", name),
+		}
+
 	}
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,7 +29,7 @@ enum Encode {
 	/// Load function from JSON ABI file.
 	Function {
 		abi_path: String,
-		function_name: String,
+		function_name_or_signature: String,
 		#[structopt(short, number_of_values = 1)]
 		params: Vec<String>,
 		/// Allow short representation of input params.
@@ -54,7 +54,7 @@ enum Decode {
 	/// Load function from JSON ABI file.
 	Function {
 		abi_path: String,
-		function_name: String,
+		function_name_or_signature: String,
 		data: String,
 	},
 	/// Specify types of input params inline.
@@ -87,12 +87,12 @@ where
 	let opt = Opt::from_iter(args);
 
 	match opt {
-		Opt::Encode(Encode::Function { abi_path, function_name, params, lenient }) =>
-			encode_input(&abi_path, &function_name, &params, lenient),
+		Opt::Encode(Encode::Function { abi_path, function_name_or_signature, params, lenient }) =>
+			encode_input(&abi_path, &function_name_or_signature, &params, lenient),
 		Opt::Encode(Encode::Params { params, lenient }) =>
 			encode_params(&params, lenient),
-		Opt::Decode(Decode::Function { abi_path, function_name, data }) =>
-			decode_call_output(&abi_path, &function_name, &data),
+		Opt::Decode(Decode::Function { abi_path, function_name_or_signature, data }) =>
+			decode_call_output(&abi_path, &function_name_or_signature, &data),
 		Opt::Decode(Decode::Params { types, data }) =>
 			decode_params(&types, &data),
 		Opt::Decode(Decode::Log { abi_path, event_name_or_signature, topics, data }) =>
@@ -100,12 +100,31 @@ where
 	}
 }
 
-fn load_function(path: &str, function: &str) -> Result<Function, Error> {
+fn load_function(path: &str, name_or_signature: &str) -> Result<Function, Error> {
 	let file = File::open(path)?;
 	let contract = Contract::load(file)?;
-	let function = contract.function(function)?.clone();
+	let params_start = name_or_signature.find('(');
 
-	Ok(function)
+	match params_start {
+		// It's a signature
+		Some(params_start) => {
+			let name = &name_or_signature[..params_start];
+
+			contract.functions_by_name(name)?.iter().find(|f| {
+				f.signature() == name_or_signature
+			}).cloned().ok_or(ErrorKind::InvalidFunctionSignature(name_or_signature.to_owned()).into())
+		},
+
+		// It's a name
+		None => {
+			let functions = contract.functions_by_name(name_or_signature)?;
+			match functions.len() {
+				0 => unreachable!(),
+				1 => Ok(functions[0].clone()),
+				_ => Err(ErrorKind::AmbiguousFunctionName(name_or_signature.to_owned()).into())
+			}
+		},
+	}
 }
 
 fn load_event(path: &str, name_or_signature: &str) -> Result<Event, Error> {
@@ -145,8 +164,8 @@ fn parse_tokens(params: &[(ParamType, &str)], lenient: bool) -> Result<Vec<Token
 		.map_err(From::from)
 }
 
-fn encode_input(path: &str, function: &str, values: &[String], lenient: bool) -> Result<String, Error> {
-	let function = load_function(path, function)?;
+fn encode_input(path: &str, name_or_signature: &str, values: &[String], lenient: bool) -> Result<String, Error> {
+	let function = load_function(path, name_or_signature)?;
 
 	let params: Vec<_> = function.inputs.iter()
 		.map(|param| param.kind.clone())
@@ -174,8 +193,8 @@ fn encode_params(params: &[String], lenient: bool) -> Result<String, Error> {
 	Ok(result.to_hex())
 }
 
-fn decode_call_output(path: &str, function: &str, data: &str) -> Result<String, Error> {
-	let function = load_function(path, function)?;
+fn decode_call_output(path: &str, name_or_signature: &str, data: &str) -> Result<String, Error> {
+	let function = load_function(path, name_or_signature)?;
 	let data : Vec<u8> = data.from_hex().chain_err(|| "Expected <data> to be hex")?;
 	let tokens = function.decode_output(&data)?;
 	let types = function.outputs;
@@ -271,9 +290,39 @@ mod tests {
 	}
 
 	#[test]
-	fn abi_encode() {
+	fn function_encode_by_name() {
 		let command = "ethabi encode function ../res/test.abi foo -p 1".split(" ");
 		let expected = "455575780000000000000000000000000000000000000000000000000000000000000001";
+		assert_eq!(execute(command).unwrap(), expected);
+	}
+
+	#[test]
+	fn function_encode_by_signature() {
+		let command = "ethabi encode function ../res/test.abi foo(bool) -p 1".split(" ");
+		let expected = "455575780000000000000000000000000000000000000000000000000000000000000001";
+		assert_eq!(execute(command).unwrap(), expected);
+	}
+
+	#[test]
+	fn overloaded_function_encode_by_name() {
+		// This should fail because there are two definitions of `bar in the ABI
+		let command = "ethabi encode function ../res/test.abi bar -p 1".split(" ");
+		assert!(execute(command).is_err());
+	}
+
+	#[test]
+	fn overloaded_function_encode_by_first_signature() {
+		let command = "ethabi encode function ../res/test.abi bar(bool) -p 1".split(" ");
+		let expected = "6fae94120000000000000000000000000000000000000000000000000000000000000001";
+		assert_eq!(execute(command).unwrap(), expected);
+	}
+
+	#[test]
+	fn overloaded_function_encode_by_second_signature() {
+		let command = "ethabi encode function ../res/test.abi bar(string):(uint256) -p 1".split(" ");
+		let expected = "d473a8ed0000000000000000000000000000000000000000000000000000000000000020\
+						000000000000000000000000000000000000000000000000000000000000000131000000\
+						00000000000000000000000000000000000000000000000000000000";
 		assert_eq!(execute(command).unwrap(), expected);
 	}
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -388,4 +388,11 @@ b 4444444444444444444444444444444444444444";
 b 4444444444444444444444444444444444444444";
 		assert_eq!(execute(command).unwrap(), expected);
 	}
+
+	#[test]
+	fn nonexistent_event() {
+		// This should return an error because no event 'Nope(bool,address)' exists
+		let command = "ethabi decode log ../res/event.abi Nope(bool,address) -l 0000000000000000000000000000000000000000000000000000000000000000 0000000000000000000000004444444444444444444444444444444444444444".split(" ");
+		assert!(execute(command).is_err());
+	}
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -304,6 +304,13 @@ mod tests {
 	}
 
 	#[test]
+	fn nonexistent_function() {
+		// This should fail because there is no function called 'nope' in the ABI
+		let command = "ethabi encode function ../res/test.abi nope -p 1".split(" ");
+		assert!(execute(command).is_err());
+	}
+
+	#[test]
 	fn overloaded_function_encode_by_name() {
 		// This should fail because there are two definitions of `bar in the ABI
 		let command = "ethabi encode function ../res/test.abi bar -p 1".split(" ");

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -14,7 +14,7 @@ pub struct Contract {
 	/// Contract constructor.
 	pub constructor: Option<Constructor>,
 	/// Contract functions.
-	pub functions: HashMap<String, Function>,
+	pub functions: HashMap<String, Vec<Function>>,
 	/// Contract events, maps signature to event.
 	pub events: HashMap<String, Vec<Event>>,
 	/// Contract has fallback function.
@@ -50,7 +50,7 @@ impl<'a> Visitor<'a> for ContractVisitor {
 					result.constructor = Some(constructor);
 				},
 				Operation::Function(func) => {
-					result.functions.insert(func.name.clone(), func);
+					result.functions.entry(func.name.clone()).or_default().push(func);
 				},
 				Operation::Event(event) => {
 					result.events.entry(event.name.clone()).or_default().push(event);
@@ -76,9 +76,15 @@ impl Contract {
 		self.constructor.as_ref()
 	}
 
-	/// Creates function call builder.
+	/// Get the function named `name`, the first if there are overloaded
+	/// versions of the same function.
 	pub fn function(&self, name: &str) -> errors::Result<&Function> {
-		self.functions.get(name).ok_or_else(|| ErrorKind::InvalidName(name.to_owned()).into())
+		self.functions
+			.get(name)
+			.into_iter()
+			.flatten()
+			.next()
+			.ok_or_else(|| ErrorKind::InvalidName(name.to_owned()).into())
 	}
 
 	/// Get the contract event named `name`, the first if there are multiple.
@@ -95,9 +101,16 @@ impl Contract {
 					.ok_or_else(|| ErrorKind::InvalidName(name.to_owned()).into())
 	}
 
+	/// Get all functions named `name`.
+	pub fn functions_by_name(&self, name: &str) -> errors::Result<&Vec<Function>> {
+		self.functions
+			.get(name)
+			.ok_or_else(|| ErrorKind::InvalidName(name.to_owned()).into())
+	}
+
 	/// Iterate over all functions of the contract in arbitrary order.
 	pub fn functions(&self) -> Functions {
-		Functions(self.functions.values())
+		Functions(self.functions.values().flatten())
 	}
 
 	/// Iterate over all events of the contract in arbitrary order.
@@ -112,7 +125,7 @@ impl Contract {
 }
 
 /// Contract functions interator.
-pub struct Functions<'a>(Values<'a, String, Function>);
+pub struct Functions<'a>(Flatten<Values<'a, String, Vec<Function>>>);
 
 impl<'a> Iterator for Functions<'a> {
 	type Item = &'a Function;

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -124,7 +124,7 @@ impl Contract {
 	}
 }
 
-/// Contract functions interator.
+/// Contract functions iterator.
 pub struct Functions<'a>(Flatten<Values<'a, String, Vec<Function>>>);
 
 impl<'a> Iterator for Functions<'a> {
@@ -135,7 +135,7 @@ impl<'a> Iterator for Functions<'a> {
 	}
 }
 
-/// Contract events interator.
+/// Contract events iterator.
 pub struct Events<'a>(Flatten<Values<'a, String, Vec<Event>>>);
 
 impl<'a> Iterator for Events<'a> {

--- a/ethabi/src/function.rs
+++ b/ethabi/src/function.rs
@@ -1,5 +1,7 @@
 //! Contract function call builder.
 
+use std::string::ToString;
+
 use signature::short_signature;
 use {Param, Token, Result, ErrorKind, Bytes, decode, ParamType, encode};
 
@@ -48,6 +50,37 @@ impl Function {
 	/// Parses the ABI function output to list of tokens.
 	pub fn decode_output(&self, data: &[u8]) -> Result<Vec<Token>> {
 		decode(&self.output_param_types(), &data)
+	}
+
+	/// Parses the ABI function input to a list of tokens.
+	pub fn decode_input(&self, data: &[u8]) -> Result<Vec<Token>> {
+		decode(&self.input_param_types(), &data)
+	}
+
+	/// Returns a signature that uniquely identifies this function.
+	///
+	/// Examples:
+	/// - `functionName()`
+	/// - `functionName():(uint256)`
+	/// - `functionName(bool):(uint256,string)`
+	/// - `functionName(uint256,bytes32):(string,uint256)`
+	pub fn signature(&self) -> String {
+		let inputs = self.inputs
+			.iter()
+			.map(|p| p.kind.to_string())
+			.collect::<Vec<_>>()
+			.join(",");
+
+		let outputs = self.outputs
+			.iter()
+			.map(|p| p.kind.to_string())
+			.collect::<Vec<_>>()
+			.join(",");
+
+		match (inputs.len(), outputs.len()) {
+			(_, 0) => format!("{}({})", self.name, inputs),
+			(_, _) => format!("{}({}):({})", self.name, inputs, outputs)
+		}
 	}
 }
 

--- a/res/test.abi
+++ b/res/test.abi
@@ -9,5 +9,33 @@
         "name": "foo",
         "outputs": [],
         "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "name": "a",
+                "type": "bool"
+            }
+        ],
+        "name": "bar",
+        "outputs": [
+        ],
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "name": "a",
+                "type": "string"
+            }
+        ],
+        "name": "bar",
+        "outputs": [
+            {
+                "name": "b",
+                "type": "uint256"
+            }
+        ],
+        "type": "function"
     }
 ]


### PR DESCRIPTION
Prior to this, ethabi would store just on function definition per function name in the `Contract` struct. This is not sufficient, in fact it is incorrect, as functions can be overloaded and there can be multiple definitions with the same name.

This applies the same treatment to contract functions that was applied earlier for events: for every name, a vector of function definitions is now stored. ethabi-cli takes either a name or a signature of the form

    functionName()
    functionName():(bool)
    functionName(uint256,string):(uint256,bool)

and matches this to the right overloaded version of the function with that name.